### PR TITLE
Adapt dracut-saltboot to dracut environment

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan  9 15:33:44 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Source wicked network information to access IPADDR and DNSDOMAIN variables
+- Replace systemException functions by log and reboot actions
+- Stop waiting for devices when dracut timeout is hit
+
+-------------------------------------------------------------------
 Wed Nov 20 14:37:09 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
 
 - Include swapon in saltboot initrd

--- a/dracut-saltboot/saltboot/saltboot-root.sh
+++ b/dracut-saltboot/saltboot/saltboot-root.sh
@@ -6,6 +6,7 @@ else
   # we have root, we can eventually continue without network after timeout
   # the timeout is controlled by rd.retry option
   echo "rm -f -- $hookdir/initqueue/finished/wait-network.sh" > $hookdir/initqueue/timeout/saltboot-network.sh
+  echo "rm -f -- $hookdir/initqueue/finished/devexists-*" > $hookdir/initqueue/timeout/saltboot-device.sh
 fi
 
 rootok=1

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -114,14 +114,14 @@ if [ -z "$CUR_MASTER" -o "salt" == "$CUR_MASTER" ] ; then
     # either we have MASTER set on commandline
     # or we try to resolve the 'salt' alias
     if [ -z "$MASTER" ] ; then
-        MASTER=`dig $DIG_OPTIONS -t CNAME salt.$DOMAIN | sed -e 's|;;.*||' -e 's|\.$||' `
+        MASTER=`dig $DIG_OPTIONS -t CNAME salt.$DNSDOMAIN | sed -e 's|;;.*||' -e 's|\.$||' `
     fi
-    # if it fails, do nothing and let it fall back to 'salt'
     if [ -n "$MASTER" ] ; then
         echo "master: $MASTER" > /etc/salt/minion.d/master.conf
     fi
     # else
     # ... if it fails, do nothing and let it fall back to 'salt'
+    # !!!!! by continuing we hide dns errors. Shouldn't we require proper setup?
 fi
 
 if [ -z "$kiwidebug" ];then
@@ -157,10 +157,8 @@ Echo "SALT Minion key fingerprint:"
 Echo "$MINION_FINGERPRINT"
 Echo
 
-if [ -e /progress ] ; then
-    # split line into two to fit to screen. Need tripple \ to properly pass through
-    echo "Terminal ID: $MINION_ID\\\nFingerprint: $MINION_FINGERPRINT" > /progress
-fi
+# split line into two to fit to screen. Need tripple \ to properly pass through
+echo "Terminal ID: $MINION_ID\\\nFingerprint: $MINION_FINGERPRINT" > /progress
 
 SALT_TIMEOUT=${SALT_TIMEOUT:-60}
 num=0
@@ -173,6 +171,7 @@ while kill -0 "$SALT_PID" >/dev/null 2>&1; do
     export systemIntegrity=fine
     export imageName=`cat $NEWROOT/etc/ImageVersion`
     echo "SUSE Manager server does not respond, trying local boot to\\\n$imageName" > /progress
+    Echo "SUSE Manager server does not respond, trying local boot to\\\n$imageName"
     kill "$SALT_PID"
     sleep 1
   fi
@@ -185,6 +184,7 @@ fi
 [ -n "$PROGRESS_PID" ] && kill $PROGRESS_PID
 
 if [ "$systemIntegrity" = "unknown" ] ; then
+   # !!!!!!! vvv  is this still valid?
    systemException \
        "SALT Minion did not create valid configuration" \
        "reboot"

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -11,6 +11,14 @@ if ! [ -s /etc/resolv.conf ] ; then
     exit 0
 fi
 
+IFCONFIG="$(compgen -G '/tmp/leaseinfo.*.dhcp.ipv*')"
+if [ -f "$IFCONFIG" ]; then
+    . "$IFCONFIG"
+else
+    Echo "No network details available, skipping saltboot";
+    exit 0
+fi
+
 NEWROOT=${NEWROOT:-/mnt}
 export NEWROOT
 

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -146,9 +146,10 @@ sleep 1
 SALT_PID=`cat /var/run/salt-minion.pid`
 
 if [ -z "$SALT_PID" ] ; then
-   systemException \
-       "SALT Minion did not start" \
-       "reboot"
+    Echo "Salt Minion did not start"
+    echo "Salt Minion did not start" > /progress
+    sleep 10
+    reboot -f
 fi
 
 MINION_ID="`salt-call --local --out newline_values_only grains.get id`"
@@ -168,7 +169,7 @@ Echo "SALT Minion key fingerprint:"
 Echo "$MINION_FINGERPRINT"
 Echo
 
-# split line into two to fit to screen. Need tripple \ to properly pass through
+# split line into two to fit to screen. Need triple \ to properly pass through
 echo "Terminal ID: $MINION_ID\\\nFingerprint: $MINION_FINGERPRINT" > /progress
 
 SALT_TIMEOUT=${SALT_TIMEOUT:-60}
@@ -183,6 +184,7 @@ while kill -0 "$SALT_PID" >/dev/null 2>&1; do
     export imageName=`cat $NEWROOT/etc/ImageVersion`
     echo "SUSE Manager server does not respond, trying local boot to\\\n$imageName" > /progress
     Echo "SUSE Manager server does not respond, trying local boot to\\\n$imageName"
+    sleep 5
     kill "$SALT_PID"
     sleep 1
   fi
@@ -195,10 +197,9 @@ fi
 [ -n "$PROGRESS_PID" ] && kill $PROGRESS_PID
 
 if [ "$systemIntegrity" = "unknown" ] ; then
-   # !!!!!!! vvv  is this still valid?
-   systemException \
-       "SALT Minion did not create valid configuration" \
-       "reboot"
+    Echo "SALT Minion did not create valid configuration"
+    sleep 10
+    reboot -f
 fi
 
 cat > /etc/salt/minion.d/grains-initrd.conf <<EOT

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -87,7 +87,7 @@ if [ -z "$HAVE_MINION_ID" ] ; then
         SMBIOS_SERIAL=
     fi
 
-    FQDN=`dig $DIG_OPTIONS -x "$IPADDR" | sed -e 's|;;.*||' -e 's|\.$||' `
+    FQDN=`dig $DIG_OPTIONS -x "${IPADDR%/*}" | sed -e 's|;;.*||' -e 's|\.$||' `
     HOSTNAME=${FQDN%%.*}
 
     if [ -n "$DISABLE_UNIQUE_SUFFIX" ] ; then

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -129,8 +129,11 @@ if [ -z "$CUR_MASTER" -o "salt" == "$CUR_MASTER" ] ; then
     fi
     # else
     # ... if it fails, do nothing and let it fall back to 'salt'
-    # !!!!! by continuing we hide dns errors. Shouldn't we require proper setup?
+    # by continuing we hide dns errors. Shouldn't we require proper setup?
 fi
+
+Echo "Using Salt master: ${MASTER:-$CUR_MASTER}"
+echo "Using Salt master: ${MASTER:-$CUR_MASTER}" > /progress
 
 if [ -z "$kiwidebug" ];then
     salt-minion -d


### PR DESCRIPTION
Dracut saltboot is a copy of kiwi-desc-saltboot script and on some places still relied on variables and functions provided by old kiwi hooks. They are no longer available in dracut.

This covers:
* source wicked network information to access IPADDR and DNSDOMAIN variables
* replase `systemException` functions by log and reboot actions

During development was discovered issue when terminal harddrive was replaced and then boot failed. This PR then also adds timeout script which stops dracut waiting for missing partition and continue as a new deployment.