### PR TITLE
Add FQDN as an option as minion id

### DIFF
--- a/branch-network-formula/branch-network-formula.changes
+++ b/branch-network-formula/branch-network-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jan 29 12:41:06 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Update formula to include terminal naming and identification
+
+-------------------------------------------------------------------
 Fri Oct 11 14:41:01 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
 
 - Update formula metadata

--- a/branch-network-formula/metadata/form.yml
+++ b/branch-network-formula/metadata/form.yml
@@ -87,14 +87,45 @@ branch_network:
     $default: True
 
   srv_directory:
-    $name:  'server directory'
+    $name:  'Server Directory for TFTP and images'
     $type: text
     $default: '/srv/saltboot'
   srv_directory_user:
-    $name: 'server directory user'
+    $name: 'Server Directory owner'
     $type: text
     $default: 'saltboot'
   srv_directory_group:
-    $name: 'server directory group'
+    $name: 'Server Directory group'
     $type: text
     $default: 'saltboot'
+
+pxe:
+  $type: group
+  $name: Terminal Naming and Identification
+  branch_id:
+    $name: Branch Identification
+    $type: text
+    $placeholder: Enter unique Branch server ID (e.g. "B0001")
+    $help: Branch server ID is used to identify to which branch server pxebooted client belongs. By default is also part of the salt client ID.
+    $required: True
+  minion_id_naming:
+    $name: Salt client naming scheme
+    $type: select
+    $values:
+      - FQDN
+      - Hostname
+      - HWType
+    $default: 'Hostname'
+    $help: HWType naming scheme names salt client by its hardware manufacturer and product. FQDN uses fully qualified domain name and Hostname uses only client hostname. If FQDN or Hostname are not avaliable, HWType naming scheme is used as fallback.
+  disable_id_prefix:
+    $name: Do not prefix salt client ID with Branch ID
+    $type: boolean
+    $default: False
+    $optional: True
+  disable_unique_suffix:
+    $name: Do not append unique suffix to the salt client ID
+    $type: boolean
+    $default: False
+    $optional: True
+    $disable: "formValues.pxe.minion_id_naming != 'HWType'"
+    $help: By default, salt client ID is suffixed by unique ID. This is to prevent naming conflict when client must be reregistered. With this option checked, client entry must be first removed from database before reregistration. Should not be used wiht HWType naming scheme.

--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,9 +1,15 @@
 -------------------------------------------------------------------
+Wed Jan 29 12:43:16 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Add support for FQDN as a terminal name
+
+-------------------------------------------------------------------
 Thu Jan  9 15:33:44 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
 
 - Source wicked network information to access IPADDR and DNSDOMAIN variables
 - Replace systemException functions by log and reboot actions
 - Stop waiting for devices when dracut timeout is hit
+- Update to version 0.1.1579102150.4716559
 
 -------------------------------------------------------------------
 Wed Nov 20 14:37:09 UTC 2019 - Ondrej Holecek <oholecek@suse.com>

--- a/kiwi-desc-saltboot/kiwi-desc-saltboot.changes
+++ b/kiwi-desc-saltboot/kiwi-desc-saltboot.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jan 29 12:42:16 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Add support for FQDN as a terminal name
+
+-------------------------------------------------------------------
 Wed Aug 21 14:25:51 UTC 2019 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Workaround for dig writing error messages to stdout

--- a/kiwi-desc-saltboot/saltboot/suse-SLES12/root/saltboot.sh
+++ b/kiwi-desc-saltboot/saltboot/suse-SLES12/root/saltboot.sh
@@ -65,16 +65,12 @@ if dig -h | grep -q '\[no\]cookie'; then
 fi
 
 if [ -z "$HAVE_MINION_ID" ] ; then
-    SMBIOS_MANUFACTURER=`salt-call --local --out newline_values_only smbios.get system-manufacturer | tr -d -c 'A-Za-z0-9_-'`
-    SMBIOS_PRODUCT=`salt-call --local --out newline_values_only smbios.get system-product-name | tr -d -c 'A-Za-z0-9_-'`
-    SMBIOS_SERIAL=-`salt-call --local --out newline_values_only smbios.get system-serial-number | tr -d -c 'A-Za-z0-9_-'`
-
-    if [ "x$SMBIOS_SERIAL" == "x-None" ] ; then
-        SMBIOS_SERIAL=
+    FQDN=`dig $DIG_OPTIONS -x "${IPADDR%/*}" | sed -e 's|;;.*||' -e 's|\.$||' `
+    if [ -n "$USE_FQDN_MINION_ID" ]; then
+        HOSTNAME="$FQDN"
+    else
+        HOSTNAME=${FQDN%%.*}
     fi
-
-    FQDN=`dig $DIG_OPTIONS -x "$IPADDR" | sed -e 's|;;.*||' -e 's|\.$||' `
-    HOSTNAME=${FQDN%%.*}
 
     if [ -n "$DISABLE_UNIQUE_SUFFIX" ] ; then
         UNIQUE_SUFFIX=
@@ -82,20 +78,31 @@ if [ -z "$HAVE_MINION_ID" ] ; then
         UNIQUE_SUFFIX="-${MACHINE_ID:0:4}"
     fi
 
-    if [ -n "$HOSTNAME" -a -z "$DISABLE_HOSTNAME_ID" ] ; then
-        # MINION_ID_PREFIX can be specified on kernel cmdline
-        if [ -n "$MINION_ID_PREFIX" ] ; then
-            echo "$MINION_ID_PREFIX.$HOSTNAME$UNIQUE_SUFFIX" > /etc/salt/minion_id
-        else
-            echo "$FQDN$UNIQUE_SUFFIX" > /etc/salt/minion_id
+    if [ -z "$HOSTNAME" ] || [ -n "$DISABLE_HOSTNAME_ID" ]; then
+        SMBIOS_MANUFACTURER=`salt-call --local --out newline_values_only smbios.get system-manufacturer | tr -d -c 'A-Za-z0-9_-'`
+        SMBIOS_PRODUCT=`salt-call --local --out newline_values_only smbios.get system-product-name | tr -d -c 'A-Za-z0-9_-'`
+        SMBIOS_SERIAL=-`salt-call --local --out newline_values_only smbios.get system-serial-number | tr -d -c 'A-Za-z0-9_-'`
+
+        if [ "x$SMBIOS_SERIAL" == "x-None" ] ; then
+            SMBIOS_SERIAL=
         fi
-    else
-        if [ -n "$MINION_ID_PREFIX" ] ; then
+
+        # MINION_ID_PREFIX can be specified on kernel cmdline
+        if [ -n "$MINION_ID_PREFIX" ] && [ -z "$DISABLE_ID_PREFIX" ] ; then
             echo "$MINION_ID_PREFIX.$SMBIOS_MANUFACTURER-$SMBIOS_PRODUCT$SMBIOS_SERIAL$UNIQUE_SUFFIX" > /etc/salt/minion_id
         else
-          echo "$SMBIOS_MANUFACTURER-$SMBIOS_PRODUCT$SMBIOS_SERIAL$UNIQUE_SUFFIX" > /etc/salt/minion_id
+            echo "$SMBIOS_MANUFACTURER-$SMBIOS_PRODUCT$SMBIOS_SERIAL$UNIQUE_SUFFIX" > /etc/salt/minion_id
+        fi
+    else
+
+        # MINION_ID_PREFIX can be specified on kernel cmdline
+        if [ -n "$MINION_ID_PREFIX" ] && [ -z "$DISABLE_ID_PREFIX" ] ; then
+            echo "$MINION_ID_PREFIX.$HOSTNAME$UNIQUE_SUFFIX" > /etc/salt/minion_id
+        else
+            echo "$HOSTNAME$UNIQUE_SUFFIX" > /etc/salt/minion_id
         fi
     fi
+
     cat > /etc/salt/minion.d/grains-minion_id_prefix.conf <<EOT
 grains:
   minion_id_prefix: $MINION_ID_PREFIX
@@ -117,6 +124,9 @@ if [ -z "$CUR_MASTER" -o "salt" == "$CUR_MASTER" ] ; then
     # else
     # ... if it fails, do nothing and let it fall back to 'salt'
 fi
+
+Echo "Using Salt master: ${MASTER:-$CUR_MASTER}"
+echo "Using Salt master: ${MASTER:-$CUR_MASTER}" > /progress
 
 if [ -z "$kiwidebug" ];then
     salt-minion -d

--- a/python-susemanager-retail/python-susemanager-retail.changes
+++ b/python-susemanager-retail/python-susemanager-retail.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jan 29 16:00:37 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Add support for terminal naming block
+
+-------------------------------------------------------------------
 Tue Dec  3 13:52:57 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
 
 - Add delta support for SLE15 tar.xz bundles


### PR DESCRIPTION
- introduce USE_FQDN_MINION_ID kernel command line option to control
  if plain hostname (if not set) or full FQDN (if set) should be used
  for minion id. This is in effect only if terminal IP is reverse
  resolvable
- introduce DISABLE_ID_PREFIX kernel command line option to control
  if BRANCH_ID should be prefixed (if not set) to the minion id or
  not (if set)