### PR TITLE
Allow http access to saltboot directory

### DIFF
--- a/branch-network-formula/branch-network-formula.changes
+++ b/branch-network-formula/branch-network-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb  3 14:26:43 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Allow http access to saltboot directory
+
+-------------------------------------------------------------------
 Wed Jan 29 12:41:06 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
 
 - Update formula to include terminal naming and identification

--- a/branch-network-formula/branch-network/files/susemanager-retail.conf.template
+++ b/branch-network-formula/branch-network/files/susemanager-retail.conf.template
@@ -1,0 +1,15 @@
+# allow http access to /srv/saltboot
+{% set branch_network_setup = salt['pillar.get']('branch_network') %}
+
+Alias "/saltboot" "{{ branch_network_setup.srv_directory }}"
+
+<Directory "{{ branch_network_setup.srv_directory }}">
+    Options Indexes FollowSymLinks
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
+</Directory>

--- a/branch-network-formula/branch-network/init.sls
+++ b/branch-network-formula/branch-network/init.sls
@@ -72,7 +72,7 @@ server_directory_setup:
     - user:  {{ branch_network_setup.srv_directory_user }}
     - name:  {{ branch_network_setup.srv_directory }}
     - group: {{ branch_network_setup.srv_directory_group }}
-    - mode:  750
+    - mode:  755
     - makedirs: True
     - require:
         - user: server_directory_setup
@@ -102,3 +102,16 @@ add_{{service}}_to_saltboot_group:
     - require:
       - file: server_directory_setup
 {% endfor %}
+
+/etc/apache2/conf.d/susemanager-retail.conf:
+  file.managed:
+    - source: salt://branch-network/files/susemanager-retail.conf.template
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+
+apache2:
+  service.running:
+    - watch:
+      - file:/etc/apache2/conf.d/susemanager-retail.conf


### PR DESCRIPTION
Add apache2 configuration to allow http access to saltboot directory. This is intended to replace ftp in the future.

apache2 is supposed to be already installed as part of proxy.
