### PR TITLE
Force installation of raid1 kernel module

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Mar 11 16:17:25 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Force installation of raid1 kernel module
+
+-------------------------------------------------------------------
 Tue Mar 10 12:26:51 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Use more reliable progress output

--- a/dracut-saltboot/saltboot/module-setup.sh
+++ b/dracut-saltboot/saltboot/module-setup.sh
@@ -28,6 +28,13 @@ get_python_pkg_deps_recursive() {
 }
 
 # called by dracut
+installkernel() {
+    # for raid support, the kernel module is needed unconditionally, even in hostonly mode
+    hostonly='' instmods raid1
+}
+
+
+# called by dracut
 install() {
     inst_multiple -o $(rpm -ql $(get_python_pkg_deps_recursive salt salt-minion) | \
                   grep -v '\.pyc$\|/etc/salt/minion_id\|/etc/salt/pki\|/usr/share/doc/\|/usr/share/man' )


### PR DESCRIPTION
By default, dracut --hostonly installs raid modules only if root is on raid device. Saltboot needs it for any raid device configured in pillars.