### PR TITLE
Assemble existing RAIDs before searching for salt configuration

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 16 16:04:39 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Assemble existing RAIDs before searching for salt configuration
+
+-------------------------------------------------------------------
 Wed Mar 11 16:17:25 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Force installation of raid1 kernel module

--- a/dracut-saltboot/saltboot/module-setup.sh
+++ b/dracut-saltboot/saltboot/module-setup.sh
@@ -47,6 +47,6 @@ install() {
     inst_hook cmdline 91 "$moddir/saltboot-root.sh"
     inst_hook pre-mount 99 "$moddir/saltboot.sh"
 
-    echo "rd.neednet=1" > "${initdir}/etc/cmdline.d/50saltboot.conf"
+    echo "rd.neednet=1 rd.auto" > "${initdir}/etc/cmdline.d/50saltboot.conf"
 }
 

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -42,6 +42,9 @@ rm /var/lib/dbus/machine-id
 dbus-uuidgen --ensure
 systemd-machine-id-setup
 
+# make sure there are no pending changes in devices
+udevadm settle -t 60
+
 salt_device=${salt_device:-${root#block:}}
 
 mkdir -p $NEWROOT


### PR DESCRIPTION
This enables similar behavior as in kiwi-desc-saltboot - existing RAIDS are assembled so saltboot can mount them and check for existing configuration.