### PR TITLE
Enable Secure Boot by default

### DIFF
--- a/POS_Image-Graphical7/POS_Image-Graphical7.changes
+++ b/POS_Image-Graphical7/POS_Image-Graphical7.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 30 11:07:13 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Enable Secure Boot by default
+
+-------------------------------------------------------------------
 Fri Jan 24 08:57:40 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
 
 - Add xfsprogs to the image description to make XFS available

--- a/POS_Image-Graphical7/graphical-7.0.0/config.sh
+++ b/POS_Image-Graphical7/graphical-7.0.0/config.sh
@@ -109,6 +109,9 @@ chkconfig firewalld on
 sed -Ei"" "s/#?GRUB_TERMINAL=.+$/GRUB_TERMINAL=gfxterm/g" /etc/default/grub
 sed -Ei"" "s/#?GRUB_GFXMODE=.+$/GRUB_GFXMODE=auto/g" /etc/default/grub
 
+# On UEFI machines use linuxefi entries
+echo 'GRUB_USE_LINUXEFI="true"' >> /etc/default/grub
+
 # Systemd controls the console font now
 echo FONT="$CONSOLE_FONT" >> /etc/vconsole.conf
 

--- a/POS_Image-Graphical7/graphical-7.0.0/root/etc/sysconfig/bootloader
+++ b/POS_Image-Graphical7/graphical-7.0.0/root/etc/sysconfig/bootloader
@@ -21,7 +21,7 @@ LOADER_TYPE="grub2"
 # take effect on any other firmware type.
 #
 #
-SECURE_BOOT="no"
+SECURE_BOOT="yes"
 
 ## Path:	System/Bootloader
 ## Description:	Bootloader configuration

--- a/POS_Image-JeOS7/POS_Image-JeOS7.changes
+++ b/POS_Image-JeOS7/POS_Image-JeOS7.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 30 11:06:06 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Enable Secure Boot by default
+
+-------------------------------------------------------------------
 Fri Jan 24 08:57:40 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
 
 - Add xfsprogs to the image description to make XFS available

--- a/POS_Image-JeOS7/jeos-7.0.0/config.sh
+++ b/POS_Image-JeOS7/jeos-7.0.0/config.sh
@@ -109,6 +109,9 @@ chkconfig firewalld on
 sed -Ei"" "s/#?GRUB_TERMINAL=.+$/GRUB_TERMINAL=gfxterm/g" /etc/default/grub
 sed -Ei"" "s/#?GRUB_GFXMODE=.+$/GRUB_GFXMODE=auto/g" /etc/default/grub
 
+# On UEFI machines use linuxefi entries
+echo 'GRUB_USE_LINUXEFI="true"' >> /etc/default/grub
+
 # Systemd controls the console font now
 echo FONT="$CONSOLE_FONT" >> /etc/vconsole.conf
 

--- a/POS_Image-JeOS7/jeos-7.0.0/root/etc/sysconfig/bootloader
+++ b/POS_Image-JeOS7/jeos-7.0.0/root/etc/sysconfig/bootloader
@@ -21,7 +21,7 @@ LOADER_TYPE="grub2"
 # take effect on any other firmware type.
 #
 #
-SECURE_BOOT="no"
+SECURE_BOOT="yes"
 
 ## Path:	System/Bootloader
 ## Description:	Bootloader configuration


### PR DESCRIPTION
With Secure Boot disabled, the image can't boot from hdd on Secure Boot enabled machines.
With Secure Boot enabled, it can boot anywhere.