### PR TITLE
Allow image-sync state on regular minion

### DIFF
--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,7 +1,16 @@
 -------------------------------------------------------------------
+Mon Jun  8 12:02:10 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Allow image-sync state on regular minion.
+  Image sync state requires branch-network pillars to get the directory
+  where to sync images. Use default `/srv/saltboot` if that pillar is
+  missing so image-sync can be applied on non branch minions as well.
+
+-------------------------------------------------------------------
 Thu Apr 16 15:21:50 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Install shim.efi on usb boot image
+- Update to version 0.1.1588156049.952b58d
 
 -------------------------------------------------------------------
 Tue Mar 24 11:05:14 UTC 2020 - Ondrej Holecek <oholecek@suse.com>

--- a/image-sync-formula/image-synchronize/sync.sls
+++ b/image-sync-formula/image-synchronize/sync.sls
@@ -3,14 +3,14 @@ support_packages:
   pkg.installed:
     - pkgs:
 # Do not install xdelta3 on SLE12 based systems. It is not available there
-{%- if (salt['grains.get']('osfullname') != 'SLES') or (salt['grains.get']('osmajorrelease')|int() != 12) %}
+{%- if (grains.get('osfullname') != 'SLES') or (grains.get('osmajorrelease')|int() != 12) %}
       - xdelta3
 {%- endif %}
       - dosfstools
 
-{%- set boot_images = salt['pillar.get']('boot_images', {}) %}
+{%- set boot_images = pillar.get('boot_images', {}) %}
 {%- set boot_images_in_use = {} %}
-{%- set rootdir = pillar['branch_network']['srv_directory'] %}
+{%- set rootdir = pillar.get('branch_network', {'srv_directory':'/srv/saltboot'})['srv_directory'] %}
 {%- set boot_dir = "boot" %}
 {%- set whitelist = salt['pillar.get']('image-synchronize:whitelist', []) %}
 


### PR DESCRIPTION
Image sync state requires branch-network pillars to get the directory where to sync images. Use default `/srv/saltboot` if that pillar is missing so image-sync can be applied on non branch minions as well.