### PR TITLE
use kexec --kexec-syscall-auto if possible

### DIFF
--- a/saltboot-formula/_states/saltboot.py
+++ b/saltboot-formula/_states/saltboot.py
@@ -1731,13 +1731,18 @@ def verify_and_boot_system(name, partitioning, images, boot_images, action = 'fa
             ret['comment'] += 'Kexec failed, doing normal reboot: ' + str(e.args)
             action = 'reboot'
         else:
+            kexec_opt = ''
+            res = __salt__['cmd.run_all']("kexec --help |grep -q kexec-syscall-auto", python_shell=True)
+            if res['retcode'] == 0:
+                kexec_opt += "--kexec-syscall-auto "
+
             # try to load kexec
             cmd = 'set -e -x ;'
             cmd += 'mkdir -p /kexec_tmp ; umount /kexec_tmp || true ;'
             cmd += 'mount -t tmpfs -o size=500M,nr_inodes=1k,mode=0755 tmpfs /kexec_tmp ;'
             cmd += kernel_download_cmd + ' ;'
             cmd += initrd_download_cmd + ' ;'
-            cmd += 'kexec -l /kexec_tmp/kernel --reuse-cmdline --append="$(cat /update_kernel_cmdline)" --initrd=/kexec_tmp/initrd'
+            cmd += 'kexec ' + kexec_opt + ' -l /kexec_tmp/kernel --reuse-cmdline --append="$(cat /update_kernel_cmdline)" --initrd=/kexec_tmp/initrd'
 
             res = __salt__['cmd.run_all'](cmd, python_shell=True)
             if res['retcode'] > 0:

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun  9 14:12:03 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- use kexec --kexec-syscall-auto if possible (bsc#1172829)
+
+-------------------------------------------------------------------
 Wed May 20 11:10:13 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Allow wildcards for device name (bsc#1170824)


### PR DESCRIPTION
kexec with default options does not work with UEFI Secure Boot. This is typically not fatal, the terminal just reboots as a fallback.
The only situation where it causes real problems is boot from USB when there is a different kernel version on Branch Server.

kexec with --kexec-syscall-auto  should work everywhere.
The option is not available on older distros.
