### PR TITLE
Disable automatic RAID assembly in saltboot phase

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 21 09:07:15 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Use automatic RAID assembly only in the first phase before
+  start of salt
+
+-------------------------------------------------------------------
 Tue May 12 10:50:54 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Print a list of available disk devices (bsc#1170824)

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -45,6 +45,9 @@ systemd-machine-id-setup
 # make sure there are no pending changes in devices
 udevadm settle -t 60
 
+# from now on, disable automatic RAID assembly
+udevproperty rd_NO_MD=1
+
 # This should be visible after pressing ESC
 Echo "Available disk devices" >&2
 Echo "ls -l /dev/disk/by-id" >&2


### PR DESCRIPTION
Use automatic udev based RAID assembly only in the first phase, to get previous salt configuration.
In second phase all changes to RAID devices are controlled by saltboot state.