### PR TITLE
Add plymouth-plugin-label-ft package

### DIFF
--- a/POS_Image-Graphical7/POS_Image-Graphical7.changes
+++ b/POS_Image-Graphical7/POS_Image-Graphical7.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jul 23 09:52:52 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Add plymouth-plugin-label-ft package to all *7 templates and set
+  them to be of SLE15SP2 version
+- Add optional dracut-wireless comment section and move wpa_suplicant
+  there
+
+-------------------------------------------------------------------
 Mon Mar 30 11:07:13 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Enable Secure Boot by default

--- a/POS_Image-Graphical7/graphical-7.0.0/config.xml
+++ b/POS_Image-Graphical7/graphical-7.0.0/config.xml
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 15 SP1 Graphical Image</specification>
+        <specification>SUSE Linux Enterprise 15 SP2 Graphical Image</specification>
     </description>
     <preferences>
         <version>7.0.0</version>
@@ -20,13 +20,8 @@
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut"></type>
     </preferences>
-    <!--    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
-    </repository>
-    -->
+
     <packages type="image">
-<package name="dracut-kiwi-live"/>
-<package name="dracut-saltboot"/>
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/> <!-- wouldn't be SUSE without that ;-) -->
         <package name="acl"/>
@@ -77,16 +72,19 @@
         <package name="kernel-firmware"/>
         <package name="kexec-tools"/>
 
+        <!-- uncomment here to enable wireless boot
+        <package name="dracut-wireless"/>
+        <package name="wpa_supplicant"/>
+        -->
+
         <package name="plymouth"/>
         <package name="plymouth-dracut"/>
         <package name="plymouth-branding-SLE"/>
-        <!-- plymouth-plugin-label-ft is not available on SLE15 SP1
         <package name="plymouth-plugin-label-ft"/>
-        -->
+
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="noto-sans-fonts"/>
-        <package name="wpa_supplicant"/>
         <package name="xfsprogs"/>              <!-- can be optionaly removed if XFS will not be used -->
         <package name="busybox"/>               <!-- this is needed if tftp is used for background image downloading -->
         <package name="bind-utils"/>

--- a/POS_Image-JeOS7/POS_Image-JeOS7.changes
+++ b/POS_Image-JeOS7/POS_Image-JeOS7.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jul 23 09:54:52 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Add plymouth-plugin-label-ft package to all *7 templates and set
+  them to be of SLE15SP2 version
+- Add optional dracut-wireless comment section and move wpa_suplicant
+  there 
+
+-------------------------------------------------------------------
 Mon Mar 30 11:06:06 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Enable Secure Boot by default

--- a/POS_Image-JeOS7/jeos-7.0.0/config.xml
+++ b/POS_Image-JeOS7/jeos-7.0.0/config.xml
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 15 SP1 JeOS</specification>
+        <specification>SUSE Linux Enterprise 15 SP2 JeOS</specification>
     </description>
     <preferences>
         <version>7.0.0</version>
@@ -19,15 +19,9 @@
 
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut"></type>
-
-
     </preferences>
-    <!--    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
-    </repository>
-    -->
-    <packages type="image">
 
+    <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/> <!-- wouldn't be SUSE without that ;-) -->
         <package name="acl"/>
@@ -77,16 +71,20 @@
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>
         <package name="kexec-tools"/>
+
+        <!-- uncomment here to enable wireless boot
+        <package name="dracut-wireless"/>
+        <package name="wpa_supplicant"/>
+        -->
+
         <package name="plymouth"/>
         <package name="plymouth-dracut"/>
         <package name="plymouth-branding-SLE"/>
-        <!-- plymouth-plugin-label-ft is not available on SLE15 SP1
         <package name="plymouth-plugin-label-ft"/>
-        -->
+
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="noto-sans-fonts"/>
-        <package name="wpa_supplicant"/>
         <package name="xfsprogs"/>              <!-- can be optionaly removed if XFS will not be used -->
         <package name="busybox"/>               <!-- this is needed if tftp is used for background image downloading -->
         <package name="bind-utils"/>


### PR DESCRIPTION
- plymouth-plugin-label-ft is now mandatory to all *7 templates and templates to be of SLE15SP2 version
- add optional dracut-wireless comment section and move wpa_suplicant there