### PR TITLE
Support autosign grains in saltboot intrd

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Sep  9 10:32:16 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Support autosign grains in saltboot intrd
+
+-------------------------------------------------------------------
 Fri Aug 14 11:46:55 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
 
 - Set wicked to use plain mac address for computing DHCP DUID

--- a/dracut-saltboot/saltboot/module-setup.sh
+++ b/dracut-saltboot/saltboot/module-setup.sh
@@ -53,5 +53,7 @@ install() {
     # wicked duid generation rules - use ll instead of default llt. ll does not include time, just mac address and generic prefix
     mkdir -p "${initdir}/etc/wicked"
     echo "<config><addrconf><dhcp6><default-duid><ll/></default-duid></dhcp6></addrconf></config>" > "${initdir}/etc/wicked/client.xml"
+
+    inst -o /etc/salt/minion.d/autosign-grains.conf
 }
 


### PR DESCRIPTION
Fix for https://github.com/SUSE/spacewalk/issues/12005
Allow configuring autosign grains in image sources or on kernel commandline.