### PR TITLE
Allow setting terminal kernel parameters in saltboot formula

### DIFF
--- a/saltboot-formula/metadata/form.yml
+++ b/saltboot-formula/metadata/form.yml
@@ -150,3 +150,8 @@ partitioning:
             $type: text
             $name: Disk Encryption Password
             $help: Password for encrypted disk. Leave blank for unencrypted disk. Image itself still can be encrypted.
+
+terminal_kernel_parameters:
+    $type: text
+    $name: Additional kernel parameters
+    $optional: True

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Sep 17 10:34:57 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Allow setting terminal kernel parameters in saltboot formula
+
+-------------------------------------------------------------------
 Thu Jul  2 09:45:33 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Better fix for rounding errors (bsc#1136857)

--- a/saltboot-formula/saltboot-reactor/pxe_update.sls
+++ b/saltboot-formula/saltboot-reactor/pxe_update.sls
@@ -4,7 +4,13 @@
 {% set event_data = data['data'] %}
 
 {% set branch_id = minion_grains.get('minion_id_prefix') %}
-{% set terminal_entry_pillar = { 'terminal_hwaddr_interfaces': minion_grains['hwaddr_interfaces'], 'salt_device': event_data.get('salt_device'), 'root': event_data.get('root'), 'boot_image': event_data['boot_image'] } %}
+{% set terminal_entry_pillar = {
+    'terminal_hwaddr_interfaces': minion_grains['hwaddr_interfaces'],
+    'salt_device': event_data.get('salt_device'),
+    'root': event_data.get('root'),
+    'boot_image': event_data['boot_image'],
+    'terminal_kernel_parameters': event_data.get('terminal_kernel_parameters', '')
+} %}
 
 handle_pxe_update_event:
   local.state.sls:

--- a/saltboot-formula/saltboot/init.sls
+++ b/saltboot-formula/saltboot/init.sls
@@ -2,6 +2,7 @@
 {%- set images = salt['pillar.get']('images', {}) %}
 {%- set boot_images = salt['pillar.get']('boot_images', {}) %}
 {%- set initrd = salt['grains.get']('saltboot_initrd') %}
+{%- set terminal_kernel_parameters = salt['pillar.get']('terminal_kernel_parameters', '') %}
 
 {% if initrd %}
 
@@ -87,6 +88,7 @@ saltboot_fstab:
   saltboot.fstab_updated:
     - partitioning: {{ partitioning|yaml }}
     - images: {{ images|yaml }}
+    - terminal_kernel_parameters: {{ terminal_kernel_parameters }}
     - require_in:
       - saltboot: boot_system
 

--- a/saltboot-formula/saltboot/init.sls
+++ b/saltboot-formula/saltboot/init.sls
@@ -88,7 +88,16 @@ saltboot_fstab:
   saltboot.fstab_updated:
     - partitioning: {{ partitioning|yaml }}
     - images: {{ images|yaml }}
+    - require_in:
+      - saltboot: boot_system
+
+saltboot_bootloader:
+  saltboot.bootloader_updated:
+    - partitioning: {{ partitioning|yaml }}
+    - images: {{ images|yaml }}
     - terminal_kernel_parameters: {{ terminal_kernel_parameters }}
+    - require:
+      - saltboot: saltboot_fstab
     - require_in:
       - saltboot: boot_system
 


### PR DESCRIPTION
https://github.com/SUSE/spacewalk/issues/12282

Kernel parameters specified in Saltboot formula are appended to kernel commandline for PXE, kexec and grub.

Kernel parameters specified in PXE formula are used only for PXE boot.