### PR TITLE
Do not use .gz suffix for default initrd symlink

### DIFF
--- a/image-sync-formula/_modules/image_sync_usb.py
+++ b/image-sync-formula/_modules/image_sync_usb.py
@@ -109,7 +109,7 @@ def create(dest, sizeMiB=300):
 
     __salt__['file.write']("{0}/boot/efi/EFI/BOOT/GRUB.CFG".format(tmpmount), configfile)
 
-    res = __salt__['cmd.run_all']("cp '{0}/boot/linux' '{0}/boot/initrd.gz' '{0}/boot/grub.cfg' '{1}/boot'".format(srv_dir, tmpmount))
+    res = __salt__['cmd.run_all']("cp '{0}/boot/linux' '{0}/boot/initrd' '{0}/boot/grub.cfg' '{1}/boot'".format(srv_dir, tmpmount))
     if res['retcode'] > 0:
         return res
 

--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct  6 15:27:43 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Do not use .gz suffix for default initrd symlink
+- Keep the old symlink "initrd.gz" for compatibility
+
+-------------------------------------------------------------------
 Mon Jun  8 12:02:10 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
 
 - Allow image-sync state on regular minion.

--- a/image-sync-formula/image-synchronize/sync.sls
+++ b/image-sync-formula/image-synchronize/sync.sls
@@ -137,10 +137,17 @@ boot_images:{{ boot_image_id }}:
 {%- if boot_image_id == default_boot_image %}
 # symlinks for default boot image
 
-{{ rootdir + '/' + boot_dir + '/initrd.gz' }}:
+{{ rootdir + '/' + boot_dir + '/initrd' }}:
   file.symlink:
     - target: {{ local_initrd_file_relative }}
     - force: True
+
+#compatibility symlink
+{{ rootdir + '/' + boot_dir + '/initrd.gz' }}:
+  file.symlink:
+    - target: initrd
+    - force: True
+
 
 {{ rootdir + '/' + boot_dir + '/linux' }}:
   file.symlink:

--- a/image-sync-formula/metadata/images.pillar.example
+++ b/image-sync-formula/metadata/images.pillar.example
@@ -16,7 +16,7 @@ images:
             #local_path: ~
 
 boot_images:
-    # "default" boot image is symlinked to "linux" and "initrd.gz" in default pxe boot entry
+    # "default" boot image is symlinked to "linux" and "initrd" in default pxe boot entry
     default:
         name: initrd-netboot-suse-SLES12
         initrd:

--- a/python-susemanager-retail/python-susemanager-retail.changes
+++ b/python-susemanager-retail/python-susemanager-retail.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct  7 10:59:52 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Use name "initrd" without .gz suffix
+
+-------------------------------------------------------------------
 Sat Feb 29 22:07:59 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
 
 - Fix retail_branch_init python error due to change in branch id

--- a/python-susemanager-retail/susemanager/retail/branch.py
+++ b/python-susemanager-retail/susemanager/retail/branch.py
@@ -128,7 +128,7 @@ class Branch:
         self.formulas['pxe'] = {
             'pxe': {
                 'default_kernel_parameters': kernel_parameters,
-                'initrd_name': 'initrd.gz',
+                'initrd_name': 'initrd',
                 'kernel_name': 'linux',
                 'pxe_root_directory': SRV_DIRECTORY
             }


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/12162