### PR TITLE
Create and use saltboot/defaults file

### DIFF
--- a/branch-network-formula/branch-network-formula.changes
+++ b/branch-network-formula/branch-network-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb  1 10:03:03 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Create saltboot/defaults file containing basic Branch
+  configuration
+
+-------------------------------------------------------------------
 Mon Mar  2 09:49:31 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Handle application/efi mime type

--- a/branch-network-formula/branch-network/files/defaults.template
+++ b/branch-network-formula/branch-network/files/defaults.template
@@ -1,0 +1,13 @@
+MINION_ID_PREFIX={{ salt['pillar.get']('pxe:branch_id', 'UnknownBranch') }}
+{%- if salt['pillar.get']('pxe:disable_id_prefix') %}
+DISABLE_ID_PREFIX=1
+{%- endif %}
+{%- if salt['pillar.get']('pxe:disable_unique_suffix') %}
+DISABLE_UNIQUE_SUFFIX=1
+{%- endif %}
+{%- set minion_id_naming = salt['pillar.get']('pxe:minion_id_naming', 'Hostname') %}
+{%- if minion_id_naming == 'FQDN' %}
+USE_FQDN_MINION_ID=1
+{%- elif minion_id_naming == 'HWType' %}
+DISABLE_HOSTNAME_ID=1
+{%- endif %}

--- a/branch-network-formula/branch-network/init.sls
+++ b/branch-network-formula/branch-network/init.sls
@@ -115,3 +115,11 @@ apache2:
   service.running:
     - watch:
       - file: /etc/apache2/conf.d/susemanager-retail.conf
+
+{{ branch_network_setup.srv_directory }}/defaults:
+  file.managed:
+    - source: salt://branch-network/files/defaults.template
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja

--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb  1 10:05:17 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Use saltboot/defaults file
+
+-------------------------------------------------------------------
 Wed Sep  9 10:32:16 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Support autosign grains in saltboot intrd

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -90,6 +90,21 @@ EOT
 
 echo $MACHINE_ID > /etc/machine-id
 
+curl -s http://salt/saltboot/defaults > /tmp/defaults
+if [ \! -s /tmp/defaults ] ; then
+    busybox tftp -g -l /tmp/defaults -r defaults $BOOTSERVERADDR
+fi
+
+if [ -s /tmp/defaults ] ; then
+    [ -z "$MINION_ID_PREFIX" ] && eval `grep ^MINION_ID_PREFIX= /tmp/defaults`
+    [ -z "$DISABLE_ID_PREFIX" ] && eval `grep ^DISABLE_ID_PREFIX= /tmp/defaults`
+    [ -z "$DISABLE_UNIQUE_SUFFIX" ] && eval `grep ^DISABLE_UNIQUE_SUFFIX= /tmp/defaults`
+    if [ -z "$USE_FQDN_MINION_ID" -a -z "$DISABLE_HOSTNAME_ID" ] ; then
+        eval `grep ^USE_FQDN_MINION_ID= /tmp/defaults`
+        eval `grep ^DISABLE_HOSTNAME_ID= /tmp/defaults`
+    fi
+fi
+
 SALT_AUTOSIGN_GRAINS=$(getarg SALT_AUTOSIGN_GRAINS=)
 if [ -n "$SALT_AUTOSIGN_GRAINS" ] ; then
     grains=


### PR DESCRIPTION
saltboot/defaults is used as a fallback if certain values are missing on kernel commandline