### PR TITLE
Add exclude arch to the RPi image props

### DIFF
--- a/POS_Image-RPi-Bootstrap/rpm-properties.xml
+++ b/POS_Image-RPi-Bootstrap/rpm-properties.xml
@@ -8,4 +8,5 @@
   <group>System/Management</group>
   <targetboot>/srv/POS_Image-RPi-Bootstrap</targetboot>
   <targetimage>/srv/POS_Image-RPi-Bootstrap/image</targetimage>
+  <excludearches>x86_64</excludearches>
 </props>


### PR DESCRIPTION
SUMA builds images for both aarch and x86_64, but we want only the
aarch one.