### PR TITLE
Fix dependencies of python libs (bsc#1188846)

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Aug  4 12:08:43 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Fix dependencies of python libs (bsc#1188846)
+
+-------------------------------------------------------------------
 Wed Jul 28 14:11:14 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Force installation of libexpat.so.1 (bsc#1188846)

--- a/dracut-saltboot/saltboot/module-setup.sh
+++ b/dracut-saltboot/saltboot/module-setup.sh
@@ -27,6 +27,21 @@ get_python_pkg_deps_recursive() {
     echo $res
 }
 
+# fix for bsc#1188846 - solve dependencies of nonexecutable python libs
+fix_python_deps() {
+    while read file ; do
+        echo "$file"
+        if [[ $file = *.so && ! -x $file ]] ; then
+            for lib in $(ldd "$file" 2>/dev/null ); do
+                [[ $lib != /* ]] && continue
+                [[ -f $lib ]] || continue
+                echo $lib
+            done
+        fi
+    done
+}
+
+
 # called by dracut
 installkernel() {
     # for raid and crypt support, the kernel module is needed unconditionally, even in hostonly mode
@@ -37,9 +52,9 @@ installkernel() {
 # called by dracut
 install() {
     inst_multiple -o $(rpm -ql $(get_python_pkg_deps_recursive salt salt-minion) | \
-                  grep -v '\.pyc$\|/etc/salt/minion_id\|/etc/salt/pki\|/usr/share/doc/\|/usr/share/man' )
+                  grep -v '\.pyc$\|/etc/salt/minion_id\|/etc/salt/pki\|/usr/share/doc/\|/usr/share/man' | \
+                  fix_python_deps )
     inst_multiple -o /usr/lib64/libffi.so.7 # dracut dependency solver does not see this
-    inst_multiple -o /usr/lib64/libexpat.so.1 # workaround for bsc#1188846
     inst_multiple -o grep dig ldconfig date dbus-uuidgen systemd-machine-id-setup dmidecode seq parted \
                      lsblk partprobe mdadm dcounter mkswap curl head md5sum resize2fs mkfs mkfs.btrfs \
                      mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.fat mkfs.vfat mkfs.xfs sync cryptsetup busybox \


### PR DESCRIPTION
This implements dependency solving for nonexecutable python library files which are ignored by dracut-install.