### PR TITLE
Prevent string operations on None

### DIFF
--- a/saltboot-formula/_states/saltboot-sle11.py
+++ b/saltboot-formula/_states/saltboot-sle11.py
@@ -82,14 +82,14 @@ def _try_umount_device(device, depth = 0):
 
     if devtree.get('type') == 'crypt':
         __salt__['cmd.run_all']("cryptsetup close " + device, output_loglevel='trace')
-    elif depth > 0 and devtree.get('type').startswith('raid'):
+    elif depth > 0 and devtree.get('type', '').startswith('raid'):
         __salt__['cmd.run_all']("mdadm --stop " + device, output_loglevel='trace')
         for i in range(5):
             # verify that the raid is already stopped - it may take some time
             tree = _lsblk_compat(device)
             if tree:
                 devtree = tree['blockdevices'][0]
-                if devtree.get('type').startswith('raid'):
+                if devtree.get('type', '').startswith('raid'):
                     __salt__['cmd.run_all']("mdadm --stop " + device, output_loglevel='trace')
                     time.sleep(1)
                     continue

--- a/saltboot-formula/_states/saltboot-sle11.py
+++ b/saltboot-formula/_states/saltboot-sle11.py
@@ -1626,7 +1626,7 @@ def fstab_updated(name, partitioning, images):
 
     return ret
 
-def bootloader_updated(name, partitioning, images, terminal_kernel_parameters=None):
+def bootloader_updated(name, partitioning, images, boot_images, terminal_kernel_parameters=None):
     '''
     Ensure that both local bootloader and pxe server are updated
     with current partitioning and image pillar,

--- a/saltboot-formula/_states/saltboot.py
+++ b/saltboot-formula/_states/saltboot.py
@@ -90,14 +90,14 @@ def _try_umount_device(device, depth = 0):
 
     if devtree.get('type') == 'crypt':
         __salt__['cmd.run_all']("cryptsetup close " + device, output_loglevel='trace')
-    elif depth > 0 and devtree.get('type').startswith('raid'):
+    elif depth > 0 and devtree.get('type', '').startswith('raid'):
         __salt__['cmd.run_all']("mdadm --stop " + device, output_loglevel='trace')
         for i in range(5):
             # verify that the raid is already stopped - it may take some time
             tree = _lsblk_compat(device)
             if tree:
                 devtree = tree['blockdevices'][0]
-                if devtree.get('type').startswith('raid'):
+                if devtree.get('type', '').startswith('raid'):
                     __salt__['cmd.run_all']("mdadm --stop " + device, output_loglevel='trace')
                     time.sleep(1)
                     continue

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 16 13:32:48 UTC 2021 - Ondrej Holecek <oholecek@suse.com>
+
+- Prevent python failure under some circumstances when filesystem
+  was not set (bsc#1192440)
+- Add missing boot_images option in SLE11 saltboot version
+
+-------------------------------------------------------------------
 Fri May 28 09:25:58 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Use kernel parameters from PXE formula also for local boot


### PR DESCRIPTION
- Some configurations without initial filesystem (filesystem set to None) could trigger string operations on None.
  Prevent this by returning empty string.

- commit 33a6428 added extra boot_images option to `bootloader_updated`, but this was not added to SLE11 variant of saltboot.
  This is then reported as warning and failed state when deploying
  SLE11 image

fixes https://github.com/SUSE/spacewalk/issues/16342