### PR TITLE
Improve image url modifications

### DIFF
--- a/saltboot-formula/_states/saltboot-sle11.py
+++ b/saltboot-formula/_states/saltboot-sle11.py
@@ -978,17 +978,20 @@ def _mangle_url(url):
     download_server = __salt__['pillar.get']('saltboot_download_server')
     download_scheme = __salt__['pillar.get']('saltboot_download_protocol')
 
-    if (download_scheme):
+    if (download_scheme and download_scheme != url_p.scheme):
         url_p = url_p._replace(scheme = download_scheme)
+
+        if (url_p.scheme.startswith('http') and not url_p.path.startswith('/saltboot/')):
+            url_p = url_p._replace(path='{0}{1}'.format('/saltboot', url_p.path))
+
+        if (not url_p.scheme.startswith('http') and url_p.path.startswith('/saltboot/')):
+            url_p = url_p._replace(path=url_p.path[9:])
 
     if (download_server):
         url_p = url_p._replace(netloc = download_server)
 
     if url_p.scheme not in supported_protocols:
         raise ValueError("Unknown scheme {0}.\n".format(url_p.scheme))
-
-    if (url_p.scheme.startswith('http') and not url_p.path.startswith('/saltboot')):
-        url_p = url_p._replace(path='{0}{1}'.format('/saltboot', url_p.path))
 
     return url_p
 

--- a/saltboot-formula/_states/saltboot.py
+++ b/saltboot-formula/_states/saltboot.py
@@ -994,17 +994,20 @@ def _mangle_url(url):
     download_server = __salt__['pillar.get']('saltboot_download_server')
     download_scheme = __salt__['pillar.get']('saltboot_download_protocol')
 
-    if (download_scheme):
+    if (download_scheme and download_scheme != url_p.scheme):
         url_p = url_p._replace(scheme = download_scheme)
+
+        if (url_p.scheme.startswith('http') and not url_p.path.startswith('/saltboot/')):
+            url_p = url_p._replace(path='{0}{1}'.format('/saltboot', url_p.path))
+
+        if (not url_p.scheme.startswith('http') and url_p.path.startswith('/saltboot/')):
+            url_p = url_p._replace(path=url_p.path[9:])
 
     if (download_server):
         url_p = url_p._replace(netloc = download_server)
 
     if url_p.scheme not in supported_protocols:
         raise ValueError("Unknown scheme {0}.\n".format(url_p.scheme))
-
-    if (url_p.scheme.startswith('http') and not url_p.path.startswith('/saltboot')):
-        url_p = url_p._replace(path='{0}{1}'.format('/saltboot', url_p.path))
 
     return url_p
 

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Feb 11 13:00:54 UTC 2022 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Improve image url modifications
+
+-------------------------------------------------------------------
 Tue Nov 16 13:32:48 UTC 2021 - Ondrej Holecek <oholecek@suse.com>
 
 - Update to version 0.1.1637232240.87d79ed


### PR DESCRIPTION
Make sure that `saltboot` part of  image url is modified only if change of the protocol is forced.
Support also removing `saltboot` on protocol change from `http` to `ftp`.
