### PR TITLE
Specify required columns in lsblk output

### DIFF
--- a/saltboot-formula/_states/saltboot.py
+++ b/saltboot-formula/_states/saltboot.py
@@ -27,7 +27,7 @@ def _part_device(disk_device, n):
 
 
 def _lsblk_compat(device):
-    res = __salt__['cmd.run_all']("lsblk -J -p {0}".format(device), output_loglevel='trace')
+    res = __salt__['cmd.run_all']("lsblk -J -p -o +MOUNTPOINT,TYPE,NAME {0}".format(device), output_loglevel='trace')
     if res['retcode'] == 0:
         return json.loads(res['stdout'])
 

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Apr 29 09:10:04 UTC 2022 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Specify required columns in lsblk output
+
+-------------------------------------------------------------------
 Tue Apr 12 09:09:42 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
 
 - Use always the same URL regardless bundle and non-bundle build


### PR DESCRIPTION
On SLE15 SP4 the default lsblk output replaced "mountpoint" field with "mountpoints".
This PR specifies, which fields are required, as suggested in lsblk man page.


