### PR TITLE
Do not try to show changes in images (bsc#1199998)

### DIFF
--- a/image-sync-formula/_states/image_sync.py
+++ b/image-sync-formula/_states/image_sync.py
@@ -78,7 +78,7 @@ def image_synced(name, rootdir, image_data):
 
        return ret
 
-    ret = __states__['file.managed'](name=local_file, source=image_data['sync']['url'], source_hash=image_hash, makedirs=True, force=True)
+    ret = __states__['file.managed'](name=local_file, source=image_data['sync']['url'], source_hash=image_hash, makedirs=True, force=True, show_changes=False)
     return ret
 
 

--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon May 30 14:21:54 UTC 2022 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Do not try to show changes in images (bsc#1199998)
+
+-------------------------------------------------------------------
 Wed Feb 10 11:53:58 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Create default for arm64 images: linux_arm64 and initrd_arm64


### PR DESCRIPTION
Salt tries to show changes if a file differs. For large images it can lead to OOM.
This PR disables it.

This code path is not used for bundle images, that's why we did not hit it earlier.
