### PR TITLE
Change kiwi-tools requires to recommends

### DIFF
--- a/dracut-saltboot/dracut-saltboot.spec
+++ b/dracut-saltboot/dracut-saltboot.spec
@@ -32,9 +32,9 @@ Requires:       bind-utils
 Requires:       cryptsetup
 Requires:       curl
 Requires:       device-mapper
-Requires:       kiwi-tools
 Requires:       parted
 Requires:       salt-minion
+Recommends:     kiwi-tools
 
 %description
 dracut module for booting SALT-based PXE images.


### PR DESCRIPTION
Because of Uyuni/SUMA client tools check validates that all packages in tools repo are installable just by using base system modules we can't require kiwi-tools which is in development module.

Kiwi-tools are still required in image templates.