### PR TITLE
Move the activation key injected by SUMA

### DIFF
--- a/POS_Image-Graphical6/graphical-6.0.0/images.sh
+++ b/POS_Image-Graphical6/graphical-6.0.0/images.sh
@@ -29,6 +29,9 @@ if [ -f /usr/bin/venv-salt-call ] ; then
   systemctl enable image-deployed-bundle.service
 
   systemctl enable migrate-to-bundle.service
+
+  # move the activation key injected by SUMA
+  mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
 else
   systemctl enable salt-minion.service
 

--- a/POS_Image-Graphical7/graphical-7.0.0/images.sh
+++ b/POS_Image-Graphical7/graphical-7.0.0/images.sh
@@ -29,6 +29,9 @@ if [ -f /usr/bin/venv-salt-call ] ; then
   systemctl enable image-deployed-bundle.service
 
   systemctl enable migrate-to-bundle.service
+
+  # move the activation key injected by SUMA
+  mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
 else
   systemctl enable salt-minion.service
 

--- a/POS_Image-JeOS6/jeos-6.0.0/images.sh
+++ b/POS_Image-JeOS6/jeos-6.0.0/images.sh
@@ -29,6 +29,9 @@ if [ -f /usr/bin/venv-salt-call ] ; then
   systemctl enable image-deployed-bundle.service
 
   systemctl enable migrate-to-bundle.service
+
+  # move the activation key injected by SUMA
+  mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
 else
   systemctl enable salt-minion.service
 

--- a/POS_Image-JeOS7/jeos-7.0.0/images.sh
+++ b/POS_Image-JeOS7/jeos-7.0.0/images.sh
@@ -29,6 +29,9 @@ if [ -f /usr/bin/venv-salt-call ] ; then
   systemctl enable image-deployed-bundle.service
 
   systemctl enable migrate-to-bundle.service
+
+  # move the activation key injected by SUMA
+  mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
 else
   systemctl enable salt-minion.service
 


### PR DESCRIPTION
SUMA always puts the activation key in /etc/salt.
It is better to move it in images.sh - this is compatible with all SUMA versions.