### PR TITLE
Fallback to local boot if the configured image is not synced

### DIFF
--- a/saltboot-formula/_states/saltboot.py
+++ b/saltboot-formula/_states/saltboot.py
@@ -1439,6 +1439,29 @@ def image_deployed(name, partitioning, images):
                 if res['result']:
                     _add_change(ret['changes'], res['changes'])
                 else:
+                    if existing:
+                        checkdevice = _luks_open(device, luks_pass)
+                        res = __salt__['cmd.run_all'](
+                            'e2fsck -y -f {0}'.format(checkdevice))
+                        if res['retcode'] == 0:
+                            # re-read the existing version to make sure the original image is still OK
+                            existing, existing_hash2 = _get_image_version(device, luks_pass)
+                            if existing and existing_hash and existing_hash == existing_hash2:
+                                ret['comment'] += "\nFallback to already installed image {0}\n".format(existing)
+                                if report_progress:
+                                    __salt__['cmd.run_all']("echo 'Fallback to already installed image {0}' > /progress ".format(existing), python_shell=True, output_loglevel='trace')
+
+                                ret1 = __states__['file.managed'](
+                                    '/salt_config',
+                                    contents = [
+                                    'export systemIntegrity=fine\n' +
+                                    'export imageName={0}\n'.format(existing) +
+                                    'export imageDiskDevice={0}\n'.format(devmap[name]['diskdevice'])
+                                ])
+
+                                __salt__['environ.setval']('saltboot_fallback', existing)
+                                return ret
+
                     ret['result'] = False
                     return ret
 
@@ -1728,6 +1751,9 @@ def bootloader_updated(name, partitioning, images, boot_images, terminal_kernel_
         'pchanges': {},
         }
 
+    if __salt__['environ.get']('saltboot_fallback'):
+        ret['comment'] = "Fallback to already installed {0}".format(__salt__['environ.get']('saltboot_fallback'))
+        return ret
 
     devmap = _device_map(partitioning)
     root_device = None
@@ -1885,6 +1911,15 @@ def verify_and_boot_system(name, partitioning, images, boot_images, action = 'fa
         report_progress = __salt__['file.is_fifo']("/progress")
 
     newroot = __salt__['environ.get']("NEWROOT", default="/mnt")
+
+    saltboot_fallback = __salt__['environ.get']('saltboot_fallback')
+    if saltboot_fallback:
+        ret['comment'] = "Fallback to already installed {0}".format(saltboot_fallback)
+        if report_progress:
+            __salt__['cmd.run_all']("echo 'Booting already installed {0}' > /progress ".format(saltboot_fallback), python_shell=True, output_loglevel='trace')
+        res = __states__['cmd.run']('sleep 1; kill `cat /var/run/venv-salt-minion.pid || cat /var/run/salt-minion.pid`', bg=True)
+        ret['comment'] += "\n" + res['comment']
+        return ret
 
     boot_image_id = _get_boot_image(partitioning, images)
     boot_image = boot_images.get(boot_image_id)

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Aug 19 12:02:53 UTC 2022 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Fallback to local boot if the configured image is not synced
+
+-------------------------------------------------------------------
 Thu Jul 28 12:50:32 UTC 2022 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Support salt bundle


### PR DESCRIPTION
This falls back to installed image if the new image, configured in pillar, can't be downloaded. This happens when the image is not synced yet.

It still ends with a failure if the requested image is missing from pillars and on other misconfigurations.

Fixes: https://github.com/SUSE/spacewalk/issues/18637
