### PR TITLE
Backport image sync boot version sorting

### DIFF
--- a/image-sync-formula/_modules/image_sync.py
+++ b/image-sync-formula/_modules/image_sync.py
@@ -107,7 +107,7 @@ def get_default_boot_image(boot_images_in_use):
     image_version is 'Major.Minor.Release' numeric version, we may have '-Revision' number at the end.
 
     """
-    if __pillar__.get('image-synchronize', {}).get('use_latest_boot_image', True):
+    if __pillar__.get('image-synchronize', {}).get('use_latest_boot_image', False):
         log.debug("Using latest version of boot image")
         version_template = r"^(?P<name>.+)-(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<release>[0-9]*)-?(?P<revision>[0-9]*)$"
         def _version_key(image_version):

--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Aug 19 08:44:34 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
+
+- Sort boot images by version instead of name-version (bsc#1196729)
+
+-------------------------------------------------------------------
 Wed Feb 10 11:53:58 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Create default for arm64 images: linux_arm64 and initrd_arm64

--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri Aug 19 08:44:34 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
 
-- Sort boot images by version instead of name-version (bsc#1196729)
+- Add option to sort boot images by version (bsc#1196729)
 
 -------------------------------------------------------------------
 Wed Feb 10 11:53:58 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>

--- a/image-sync-formula/image-synchronize/sync.sls
+++ b/image-sync-formula/image-synchronize/sync.sls
@@ -77,7 +77,7 @@ images:{{ image_id }}:{{ image_version }}:
 {%- if default_boot_image not in boot_images_in_use %}
 {%-   if default_boot_image not in boot_images %}
 {%-     if boot_images_in_use|length > 0 %}
-{%-       set new_default_boot_image = (boot_images_in_use.keys()|sort)[0] %}
+{%-       set new_default_boot_image = salt['image_sync.get_default_boot_image'](boot_images_in_use.keys()) %}
 
 default_boot_image_missing:
   test.show_notification:


### PR DESCRIPTION
Backport of https://github.com/uyuni-project/retail/pull/104 but disable version sorting by default for 4.2