### PR TITLE
Retail form updates

### DIFF
--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,4 +1,4 @@
-- Add form entry for use lates boot image pillar value
+- Add form entry for use lates boot image pillar value (bsc#1206055)
 -------------------------------------------------------------------
 Fri Aug 26 13:32:05 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
 

--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,3 +1,4 @@
+- Add form entry for use lates boot image pillar value
 -------------------------------------------------------------------
 Fri Aug 26 13:32:05 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
 

--- a/image-sync-formula/metadata/form.yml
+++ b/image-sync-formula/metadata/form.yml
@@ -7,13 +7,20 @@ image-synchronize:
 
     whitelist:
         $type: edit-group
-        $name: Synchronize only the listed images
+        $name: Synchronize only the listed images. Enter image names without image version.
         $minItems: 0
         $prototype:
             $type: text
             $help: Image name (without version)
 
+    use_latest_boot_image:
+        $name: Use latest boot image version as default boot image
+        $help: If set, newest boot image version is used as default boot image. If not set, first synchronized boot image is used as default boot image. Default boot image is used for not yet registered machines without specific PXE configuration.
+        $type: boolean
+        $disabled: this.parent.value.default_boot_image != ""
+        $default: true
+
     default_boot_image:
         $type: text
         $name: Default boot image
-        $help: Default boot image used for first boot of a terminal
+        $help: Default boot image used for first boot of not yest registered machines without specific PXE configuration. Setting default boot image disables any autodetection.

--- a/image-sync-formula/metadata/form.yml
+++ b/image-sync-formula/metadata/form.yml
@@ -7,7 +7,8 @@ image-synchronize:
 
     whitelist:
         $type: edit-group
-        $name: Synchronize only the listed images. Enter image names without image version.
+        $name: Synchronize only the listed images.
+        $help: Synchronize only the listed images. Enter image names without image version.
         $minItems: 0
         $prototype:
             $type: text

--- a/saltboot-formula/metadata/form.yml
+++ b/saltboot-formula/metadata/form.yml
@@ -155,3 +155,15 @@ terminal_kernel_parameters:
     $type: text
     $name: Additional kernel parameters
     $optional: True
+
+saltboot:
+    $type: hidden-group
+    kernel_action:
+        $type: select
+        $name: Kernel change method
+        $help: When Saltboot detects kernel version change or kernel parameters change it can either reboot machine or kexec to new kernel. This value selects desired method. Default is kexec.
+        $optional: True
+        $default: kexec
+        $values:
+          - kexec
+          - reboot

--- a/saltboot-formula/metadata/form.yml
+++ b/saltboot-formula/metadata/form.yml
@@ -167,3 +167,4 @@ saltboot:
         $values:
           - kexec
           - reboot
+          - fail

--- a/saltboot-formula/metadata/saltboot-group-form.yml
+++ b/saltboot-formula/metadata/saltboot-group-form.yml
@@ -1,26 +1,34 @@
 saltboot:
   $type: hidden-group
 
+  download_server:
+    $name: Image download server
+    $type: text
+    $optional: True
+    $help: Server to download images from. Enter saltboot group proxy (branch server) or SUSE Manager Server if connected directly.
+  containerized_proxy:
+    $name: Branch server is containerized proxy
+    $optional: True
+    $default: False
+    $type: boolean
+    $help: Enable this when saltboot group proxy (branch server) is running as containerized proxy.
   default_boot_image:
     $name: Default boot image for new registrations
     $type: text
     $optional: True
+    $visible: this.parent.value.containerized_proxy
     $help: Clients not yet registered need to boot some default image. If automatic selection does not work for you, this option can be used to customize it.
   default_boot_image_version:
     $name: Default boot image version
     $type: text
     $optional: True
-    $visible: this.parent.value.default_boot_image != ''
+    $visible: this.parent.value.default_boot_image != '' && this.parent.value.containerized_proxy
   default_kernel_parameters:
     $name: Kernel parameters for the group
     $type: text
     $help: Kernel parameters to be appended for all terminals registered in this group
+    $visible: this.parent.value.containerized_proxy
     $optional: True
-  download_server:
-    $name: Image download server
-    $type: text
-    $optional: True
-    $help: Server to download images from. Enter saltboot group proxy server or SUSE Manager Server if connected directly.
   minion_id_naming:
     $name: Saltboot client naming scheme
     $type: select
@@ -29,16 +37,19 @@ saltboot:
       - Hostname
       - HWType
     $default: 'Hostname'
+    $visible: this.parent.value.containerized_proxy
     $help: HWType naming scheme names salt client by its hardware manufacturer and product. FQDN uses fully qualified domain name and Hostname uses only client hostname. If FQDN or Hostname are not avaliable, HWType naming scheme is used as fallback.
   disable_id_prefix:
     $name: Do not prefix salt client ID with saltboot group ID
     $type: boolean
     $default: False
     $optional: True
+    $visible: this.parent.value.containerized_proxy
   disable_unique_suffix:
     $name: Do not append unique suffix to the salt client ID
     $type: boolean
     $default: False
     $optional: True
-    $disable: "formValues.pxe.minion_id_naming != 'HWType'"
-    $help: By default, salt client ID is suffixed by unique ID. This is to prevent naming conflict when client must be reregistered. With this option checked, client entry must be first removed from database before reregistration. Should not be used wiht HWType naming scheme
+    $disabled: this.parent.value.minion_id_naming == 'HWType'
+    $visible: this.parent.value.containerized_proxy
+    $help: Unique ID suffix of the salt client ID is used to prevent naming conflict when client must be reregistered. With this option checked, client entry must be first removed from database before reregistration. Cannot be used with HWType naming scheme.

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,3 +1,4 @@
+- Add use case of saltboot group formula outside containerized env
 - Add 'kernel_action' to saltboot form
 -------------------------------------------------------------------
 Fri Aug 26 13:31:28 UTC 2022 - Ondrej Holecek <oholecek@suse.com>

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,5 +1,6 @@
 - Add use case of saltboot group formula outside containerized env
-- Add 'kernel_action' to saltboot form
+  (bsc#1206186)
+- Add 'kernel_action' to saltboot form (bsc#1206055)
 -------------------------------------------------------------------
 Fri Aug 26 13:31:28 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
 

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,3 +1,4 @@
+- Add 'kernel_action' to saltboot form
 -------------------------------------------------------------------
 Fri Aug 26 13:31:28 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
 


### PR DESCRIPTION
Expose known pillar values to the form:

- image-sync: use latest boot image as default
- saltboot: ability to select reboot or kexec