### PR TITLE
Remove unnecessary import of "salt.ext.six"

### DIFF
--- a/branch-network-formula/sysconfig/_states/sysconfig.py
+++ b/branch-network-formula/sysconfig/_states/sysconfig.py
@@ -13,9 +13,6 @@ Manage sysconfig files
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Salt libs
-from salt.ext import six
-
 __virtualname__ = 'sysconfig'
 
 def __virtual__():


### PR DESCRIPTION
This unnecessary import is causing problems with Salt 3006.0, as `salt.ext.six` has been removed.

Apparently, this import is actually never used, so it seems it is safe to remove it.