### PR TITLE
Add osimage cert package to bootstrap for SLE12 images

### DIFF
--- a/kiwi-desc-saltboot/kiwi-desc-saltboot.changes
+++ b/kiwi-desc-saltboot/kiwi-desc-saltboot.changes
@@ -1,3 +1,5 @@
+- Add osimage cert package to bootstrap for SLE12 images (bsc#1204089)
+
 -------------------------------------------------------------------
 Mon Jan  9 15:59:28 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
 

--- a/kiwi-desc-saltboot/saltboot/suse-SLES12/config.xml
+++ b/kiwi-desc-saltboot/saltboot/suse-SLES12/config.xml
@@ -255,6 +255,7 @@
         <package name="psmisc"/>
         <package name="sysvinit-tools"/>
         <package name="e2fsprogs"/>
+        <package name="rhn-org-trusted-ssl-cert-osimage"/>
     </packages>
     <packages type="delete" profiles="default,diskless,xen,wireless">
         <package name="cracklib-dict-full"/>


### PR DESCRIPTION
- when KiwiNG is used to build SLE12 images, bootstrap package specified on command line is not propagated to the bootimage. Lets add it explicitely in the image then.