### PR TITLE
Add support to filter individual image versions in whitelist, improved cache handling

### DIFF
--- a/image-sync-formula/_modules/image_sync.py
+++ b/image-sync-formula/_modules/image_sync.py
@@ -50,9 +50,9 @@ def filter_images(whitelist = [], arch_list = ['x86_64', 'i586', 'i686']):
     images = __pillar__.get('images', {})
     res = []
     for image_id, image_versions in images.items():
-        if whitelist and image_id not in whitelist:
-            continue
         for image_version, image_data in image_versions.items():
+            if whitelist and image_id not in whitelist and image_id + '-' + image_version not in whitelist:
+                continue
             if 'filename' not in image_data:
                 continue
             if image_data.get('arch') not in arch_list:

--- a/image-sync-formula/_states/image_sync.py
+++ b/image-sync-formula/_states/image_sync.py
@@ -86,7 +86,24 @@ def image_synced(name, rootdir, image_data):
             ret['changes'] = {'new': local_file}
             return ret
 
-    ret = __states__['file.managed'](name=local_file, source=image_data['sync']['url'], source_hash=image_hash, makedirs=True, force=True, show_changes=False)
+    ret = __states__['file.managed'](name=local_file, source=image_data['sync']['url'], source_hash=image_hash, makedirs=True, force=True, show_changes=False, keep_source=False)
     return ret
 
 
+def file_synced(name, source, source_hash):
+    ret = {
+        'name': name,
+        'changes': {},
+        'result': True,
+        'comment': '',
+        'pchanges': {},
+        }
+    parsed_hash = __salt__['file.get_source_sum'](source_hash=source_hash)
+    have_sum = __salt__['file.get_sum'](name, parsed_hash['hash_type'])
+
+    if (have_sum == parsed_hash['hsum']):
+        ret['comment'] = "File hash OK"
+        return ret
+
+    ret = __states__['file.managed'](name=name, source=source, source_hash=source_hash, makedirs=True, force=True, show_changes=False, keep_source=False)
+    return ret

--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -2,6 +2,7 @@
 Thu May  4 11:01:54 UTC 2023 - Vladimir Nadvornik <nadvornik@suse.cz>
 
 - Add support to filter individual image versions in whitelist
+- Delete cache files that are no longer needed
 
 -------------------------------------------------------------------
 Thu Apr 27 13:56:56 UTC 2023 - Vladimir Nadvornik <nadvornik@suse.cz>

--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May  4 11:01:54 UTC 2023 - Vladimir Nadvornik <nadvornik@suse.cz>
+
+- Add support to filter individual image versions in whitelist
+
+-------------------------------------------------------------------
 Thu Apr 27 13:56:56 UTC 2023 - Vladimir Nadvornik <nadvornik@suse.cz>
 
 - Do not delete boot images which are referenced in PXE entries

--- a/image-sync-formula/image-synchronize/sync.sls
+++ b/image-sync-formula/image-synchronize/sync.sls
@@ -51,12 +51,18 @@ images:{{ image_id }}:{{ image_version }}:
 {%-     set local_path_relative = image_data['sync'].get('local_path') %}
 {%-     set local_path = rootdir + '/' + local_path_relative %}
 {%-     set local_file = local_path + '/' + name %}
+{%-     set local_bundle_cache = salt["cp.is_cached"](image_data['sync'].get('bundle_url', "missing")) %}
 
 {%- if local_path_relative %}
 {{ local_path }}:
   file.absent
 {%- else %}
 {{ local_file }}:
+  file.absent
+{%- endif %}
+
+{%- if local_bundle_cache %}
+{{ local_bundle_cache }}:
   file.absent
 {%- endif %}
 
@@ -133,18 +139,16 @@ default_boot_image_not_synced:
 
 {%- if boot_image_data['sync']['kernel_url'] is defined %}
 {{ local_kernel_file }}:
-  file.managed:
+  image_sync.file_synced:
     - source: {{ boot_image_data['sync']['kernel_url'] }}
     - source_hash: {{ kernel_hash }}
-    - makedirs: True
 {%- endif %}
 
 {%- if boot_image_data['sync']['initrd_url'] is defined %}
 {{ local_initrd_file }}:
-  file.managed:
+  image_sync.file_synced:
     - source: {{ boot_image_data['sync']['initrd_url'] }}
     - source_hash: {{ initrd_hash }}
-    - makedirs: True
 {%- endif %}
 
 # store synced boot images in grains

--- a/image-sync-formula/metadata/form.yml
+++ b/image-sync-formula/metadata/form.yml
@@ -8,7 +8,7 @@ image-synchronize:
     whitelist:
         $type: edit-group
         $name: Synchronize only the listed images.
-        $help: Synchronize only the listed images. Enter image names without image version.
+        $help: Synchronize only the listed images. Enter image name or name-version-revision.
         $minItems: 0
         $prototype:
             $type: text


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/18638

The second commit deletes cached files that are no longer needed.