### PR TITLE
Fix custom_info boolean check

### DIFF
--- a/saltboot-formula/_states/saltboot.py
+++ b/saltboot-formula/_states/saltboot.py
@@ -965,7 +965,7 @@ def _get_image_for_part(images, part):
     image_id = part.get('image')
     image_version = part.get('image_version')
 
-    freeze = __salt__['pillar.get']('saltboot:freeze_image') or __salt__['pillar.get']('custom_info:saltboot_freeze_image') not in [None, 'false', 'False', '0']
+    freeze = __salt__['pillar.get']('saltboot:freeze_image', False) or __salt__['pillar.get']('custom_info:saltboot_freeze_image', False) not in [False, 'false', 'False', '0']
     if freeze:
         if _is_luks(part.get('device')):
             # the image is encrypted and we do not know, which image it is

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 27 13:01:42 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
+
+- Fix custom info freeze boolean check (bsc#1212771)
+
+-------------------------------------------------------------------
 Wed May 31 09:29:54 UTC 2023 - Vladimir Nadvornik <nadvornik@suse.cz>
 
 - Update to version 0.1.1687520761.cefb248


### PR DESCRIPTION
When dict key is not present, it is not present as `None`, but empty string. Let's ask explicitly for `False` instead and check for that.