### PR TITLE
Fix boot image version sort to use numeric compare

### DIFF
--- a/image-sync-formula/_modules/image_sync.py
+++ b/image-sync-formula/_modules/image_sync.py
@@ -121,7 +121,7 @@ def get_default_boot_image(boot_images_in_use):
         version_template = r"^(?P<name>.+)-(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<release>[0-9]*)-?(?P<revision>[0-9]*)$"
         def _version_key(image_version):
             ver = re.search(version_template, image_version)
-            return ver.group("major", "minor", "release", "revision")
+            return [int(v) for v in ver.group("major", "minor", "release", "revision")]
         return sorted(boot_images_in_use,key=_version_key, reverse=True)[0]
     log.debug("Using first alphabetical boot image")
     return sorted(boot_images_in_use)[0]

--- a/image-sync-formula/image-sync-formula.changes
+++ b/image-sync-formula/image-sync-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug  8 09:00:00 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
+
+- Fix boot image version compare to use numeric instead of string
+  (bsc#1214002)
+
+-------------------------------------------------------------------
 Thu May  4 11:01:54 UTC 2023 - Vladimir Nadvornik <nadvornik@suse.cz>
 
 - Add support to filter individual image versions in whitelist


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/22209