### PR TITLE
Load first available leaseinfo, prefer those with BOOTFILE set

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,3 +1,5 @@
+- Load only first available leaseinfo (bsc#1221092)
+
 -------------------------------------------------------------------
 Wed Apr 19 11:49:39 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
 

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -26,7 +26,10 @@ fi
 
 NET_TIMEOUT=30
 while [ $NET_TIMEOUT -gt 0 ] ; do
-    IFCONFIG="$(compgen -G '/tmp/leaseinfo.*.dhcp.ipv*')"
+    IFCONFIG="$(compgen -G '/tmp/leaseinfo.*.dhcp.ipv*' | xargs grep -l BOOTFILE | head -1)"
+    if [ ! -f "$IFCONFIG" ] ; then
+        IFCONFIG="$(compgen -G '/tmp/leaseinfo.*.dhcp.ipv*' | head -1)"
+    fi
     if [ -s /etc/resolv.conf ] && [ -f "$IFCONFIG" ] ; then
         break
     fi


### PR DESCRIPTION
For some reason sometimes dracut-wicked can generate multiple leaseinfo files. This PR tries to pickup the fist one with PXE info in it, if that is not found it blindly takes first available.

In the non-containerized deployment we do not add IPAPPEND for the PXE so we cannot count with BOOTIF present on the kernel command line to check the interface we booted from, let's use this heuristic.