### PR TITLE
Do not specify keytable in POS_Image-RPi-Bootstrap

### DIFF
--- a/POS_Image-RPi-Bootstrap/POS_Image-RPi-Bootstrap.changes
+++ b/POS_Image-RPi-Bootstrap/POS_Image-RPi-Bootstrap.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr 16 12:50:02 UTC 2024 - Vladimir Nadvornik <nadvornik@suse.cz>
+
+- do not specify keytable
+
+-------------------------------------------------------------------
 Mon Jan  3 08:41:45 UTC 2022 - Michael Calmer <mc@suse.com>
 
  - remove obsolete suseConfig call

--- a/POS_Image-RPi-Bootstrap/POS_Image-RPi-Bootstrap.kiwi
+++ b/POS_Image-RPi-Bootstrap/POS_Image-RPi-Bootstrap.kiwi
@@ -13,7 +13,6 @@
         <bootloader-theme>SLE</bootloader-theme>
 
         <locale>en_US</locale>
-        <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
         <hwclock>utc</hwclock>
 


### PR DESCRIPTION
Package kbd is no longer installed via dependencies.
POS_Image-RPi-Bootstrap does not need any keyboard map.