### PR TITLE
Replace image download URLs based on API host

### DIFF
--- a/python-susemanager-retail/python-susemanager-retail.changes
+++ b/python-susemanager-retail/python-susemanager-retail.changes
@@ -1,3 +1,5 @@
+* Fix delta creation on containerized server (bsc#1226369)
+
 -------------------------------------------------------------------
 Fri Jul 15 12:30:15 UTC 2022 - Vladimir Nadvornik <nadvornik@suse.com>
 

--- a/python-susemanager-retail/retail_create_delta
+++ b/python-susemanager-retail/retail_create_delta
@@ -1,9 +1,11 @@
 #!/usr/bin/python
 import os
 import sys
+import ssl
 import yaml
 import re
 import tempfile
+from urllib.parse import urlparse
 import urllib.request
 import socket
 import subprocess
@@ -22,23 +24,36 @@ _cat_list = {
     '': ''
 }
 
+def _mangle_url(url, host):
+    url_p = urlparse(url)
+    url_p = url_p._replace(netloc = host)
+    return url_p.geturl()
+
+def _getFqdn(url):
+    url_p = urlparse(url)
+    return url_p.hostname
+
 def generate_bundle_delta(src_pillar, target_pillar, delta_path, args):
     src_bundle_url = src_pillar.get('sync', {}).get('bundle_url')
     target_bundle_url = target_pillar.get('sync', {}).get('bundle_url')
     log.debug("source bundle url: {}".format(src_bundle_url))
     log.debug("target bundle url: {}".format(target_bundle_url))
+    src_bundle_url = _mangle_url(src_bundle_url, args.api_host)
+    target_bundle_url = _mangle_url(target_bundle_url, args.api_host)
+    log.debug("mangled source url: {}".format(src_bundle_url))
+    log.debug("mangled target url: {}".format(target_buntle_url))
     tmpdir = tempfile.mkdtemp()
     try:
         src_cat = _cat_list[next(filter(lambda x: src_bundle_url.endswith(x), _cat_list.keys()))]
         target_cat = _cat_list[next(filter(lambda x: target_bundle_url.endswith(x), _cat_list.keys()))]
 
-        subprocess.check_call("cd '{}' ; curl -s -f -L '{}' {} | tar x".format(tmpdir, src_bundle_url, src_cat), shell=True)
+        subprocess.check_call("cd '{}' ; curl -s -k -f -L '{}' {} | tar x".format(tmpdir, src_bundle_url, src_cat), shell=True)
 
         extra_args = ''
         if args.B is not None:
             extra_args += "-B " + args.B
 
-        subprocess.check_call("curl -s -f -L '{}' {} | xdelta3 -e {} -s '{}' > '{}'".format(target_bundle_url, target_cat, extra_args, os.path.join(tmpdir, src_pillar.get('filename')), delta_path), shell=True)
+        subprocess.check_call("curl -s -k -f -L '{}' {} | xdelta3 -e {} -s '{}' > '{}'".format(target_bundle_url, target_cat, extra_args, os.path.join(tmpdir, src_pillar.get('filename')), delta_path), shell=True)
     finally:
         shutil.rmtree(tmpdir)
 
@@ -48,16 +63,21 @@ def generate_system_delta(src_pillar, target_pillar, delta_path, args):
     target_url = target_pillar.get('sync', {}).get('url')
     log.debug("source url: {}".format(src_url))
     log.debug("target url: {}".format(target_url))
+    src_url = _mangle_url(src_url, args.api_host)
+    target_url = _mangle_url(target_url, args.api_host)
+    log.debug("mangled source url: {}".format(src_url))
+    log.debug("mangled target url: {}".format(target_url))
     tmpdir = tempfile.mkdtemp()
     try:
         tmp_src = os.path.join(tmpdir, src_pillar.get('filename'))
+        ssl._create_default_https_context = ssl._create_unverified_context
         urllib.request.urlretrieve(src_url, tmp_src)
 
         extra_args = ''
         if args.B is not None:
             extra_args += "-B " + args.B
 
-        subprocess.check_call("curl -s -f -L '{}' | xdelta3 -e {} -s '{}' > '{}'".format(target_url, extra_args, tmp_src, delta_path), shell=True)
+        subprocess.check_call("curl -s -k -f -L '{}' | xdelta3 -e {} -s '{}' > '{}'".format(target_url, extra_args, tmp_src, delta_path), shell=True)
     finally:
         shutil.rmtree(tmpdir)
 
@@ -201,24 +221,24 @@ try:
                  target_image.get('name'), target_image.get('version'), target_image.get('revision'),
                  src_image.get('name'), src_image.get('version'), src_image.get('revision'))
 
-    fqdn = socket.getfqdn()
-    delta_url = "https://{0}/os-images/{1}/{2}".format(fqdn, org_id, delta_file)
-
     src_bundle_url = src_pillar.get('sync', {}).get('bundle_url')
     target_bundle_url = target_pillar.get('sync', {}).get('bundle_url')
 
     src_url = src_pillar.get('sync', {}).get('url')
     target_url = target_pillar.get('sync', {}).get('url')
 
+    fqdn = _getFqdn(target_url)
     if src_bundle_url and target_bundle_url:
         generate_bundle_delta(src_pillar, target_pillar, img_path + delta_file, args)
         delta_type = "bundle_delta"
+        fqdn = _getFqdn(target_bundle_url)
     elif src_url and target_url:
         generate_system_delta(src_pillar, target_pillar, img_path + delta_file, args)
         delta_type = "system_delta"
     else:
         raise RuntimeError("Inconsistent image pillars. Can't create delta")
 
+    delta_url = "https://{0}/os-images/{1}/{2}".format(fqdn, org_id, delta_file)
     delta_pillar = generate_pillar(src_name, src_version, src_revision, target_name, target_version, target_revision, img_path + delta_file, delta_url, org_id, delta_type)
 
     client.image.delta.createDeltaImage(key, src_id, target_id, delta_file, delta_pillar)


### PR DESCRIPTION
This script is by default only available on the server container, however inside container because of hairpin problem we cannot use image URLs as set in the pillar. This PR modifies download URL to use API host instead (and disable SSL verification because of it).

Also removes socket.getFqdn for delta url and use host from image url instead.

Issue: https://github.com/SUSE/spacewalk/issues/24648