### PR TITLE
Rework request stop function to avoid unnecessary warnings

### DIFF
--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,3 +1,6 @@
+* Rework request stop function to avoid unnecessary warnings
+  (bsc#1212985)
+
 -------------------------------------------------------------------
 Mon Jan 15 10:25:47 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
 


### PR DESCRIPTION
Dracut saltboot stop file checks only for presence as it has pid information when starting minion.
So first rely on grains pid info and then check if we happen to have pid files and issue kill.
If none is available, rely on external kill from dracut.