### PR TITLE
Reboot on salt key timeout (bsc#1237495)

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar  3 14:38:30 UTC 2025 - Vladimir Nadvornik <nadvornik@suse.cz>
+
+- Reboot on salt key timeout (bsc#1237495)
+
+-------------------------------------------------------------------
 Fri Oct 25 11:36:30 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
 
 - Update to version 0.1.1728559936.c16d4fb

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -278,9 +278,18 @@ if [ -z "$SALT_PID" ] ; then
     reboot -f
 fi
 
+SALT_TIMEOUT=${SALT_TIMEOUT:-60}
+
 MINION_ID="`$INITRD_SALT_CALL --local --out newline_values_only grains.get id`"
 MINION_FINGERPRINT="`$INITRD_SALT_CALL --local --out newline_values_only key.finger`"
+num=0
 while [ -z "$MINION_FINGERPRINT" ] ; do
+  num=$(( num + 1 ))
+  if [ "$num" == "$SALT_TIMEOUT" ] ; then
+    Echo "Can't get salt key, rebooting in 10s"
+    sleep 10
+    reboot -f
+  fi
   Echo "Waiting for salt key..."
   sleep 1
   MINION_FINGERPRINT="`$INITRD_SALT_CALL --local --out newline_values_only key.finger`"
@@ -297,7 +306,6 @@ echo
 # split line into two to fit to screen. Need triple \ to properly pass through
 Echo "Terminal ID: $MINION_ID\\\nFingerprint: $MINION_FINGERPRINT" > /progress
 
-SALT_TIMEOUT=${SALT_TIMEOUT:-60}
 SALT_STOP_TIMEOUT=${SALT_STOP_TIMEOUT:-15}
 SALT_STOP='/root/saltstop'
 num=0


### PR DESCRIPTION
Salt minion sometimes fails to create minion key. This PR adds a reboot after timeout to prevent infinite waiting.