### PR TITLE
Introduce rd.saltboot namespace, mark rest as deprecated

### DIFF
--- a/dracut-saltboot/saltboot/module-setup.sh
+++ b/dracut-saltboot/saltboot/module-setup.sh
@@ -12,7 +12,7 @@ depends() {
 }
 
 get_python_pkg_deps() {
-    rpm -q --requires "$@" |grep ^python3 | while read req ver; do
+    rpm -q --requires "$@" | grep ^python3 | while read -r req _; do
         rpm -q --whatprovides "$req"
     done | sort -u
 }
@@ -24,18 +24,18 @@ get_python_pkg_deps_recursive() {
        deps=$(get_python_pkg_deps $deps)
        res=$(echo -e "$res\n$deps" |sort -u)
     done
-    echo $res
+    echo "$res"
 }
 
 # fix for bsc#1188846 - solve dependencies of nonexecutable python libs
 fix_python_deps() {
-    while read file ; do
-        echo "$file"
-        if [[ $file = *.so && ! -x $file ]] ; then
-            for lib in $(ldd "$file" 2>/dev/null ); do
-                [[ $lib != /* ]] && continue
-                [[ -f $lib ]] || continue
-                echo $lib
+    while read -r f ; do
+        echo "$f"
+        if [[ $f = *.so && ! -x $f ]] ; then
+            for lib in $(ldd "$f" 2>/dev/null ); do
+                [[ "$lib" != /* ]] && continue
+                [[ -f "$lib" ]] || continue
+                echo "$lib"
             done
         fi
     done
@@ -88,4 +88,3 @@ install() {
 
     inst -o /etc/salt/minion.d/autosign-grains.conf
 }
-

--- a/dracut-saltboot/saltboot/saltboot-root.sh
+++ b/dracut-saltboot/saltboot/saltboot-root.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+command -v getarg > /dev/null || . /lib/dracut-lib.sh
+
 if [ -z "$root" ] ; then
   root=saltboot
 fi
@@ -8,22 +10,40 @@ rootok=1
 
 # If we don't have a server, we need dhcp
 if [ -z "$server" ] ; then
-    DHCPORSERVER="1"
+  DHCPORSERVER="1"
 fi;
 
+# Saltboot prefix
+_prefix="rd.saltboot"
+
 # Salt minion modifiers
-export MASTER=$(getarg MASTER=)
-export MINION_ID_PREFIX=$(getarg MINION_ID_PREFIX=)
-export SALT_TIMEOUT=$(getarg SALT_TIMEOUT=)
-export SALT_STOP_TIMEOUT=$(getarg SALT_STOP_TIMEOUT=)
-export salt_device=$(getarg salt_device=)
+MASTER=$(getarg "${_prefix}.master=" -d -y "MASTER=")
+export MASTER
+
+MINION_ID_PREFIX=$(getarg "${_prefix}.id_prefix=" -d -y "MINION_ID_PREFIX=")
+export MINION_ID_PREFIX
+
+SALT_TIMEOUT=$(getargnum 60 10 3600 "${_prefix}.timeout=" -d -y "SALT_TIMEOUT=")
+export SALT_TIMEOUT
+
+SALT_STOP_TIMEOUT=$(getargnum 15 1 60 "${_prefix}.stop_timeout=" -d -y "SALT_STOP_TIMEOUT=")
+export SALT_STOP_TIMEOUT
+
+salt_device=$(getarg "${_prefix}.device=" -d -y "salt_device")
+export salt_device
 
 # Terminal naming modifiers
-export DISABLE_UNIQUE_SUFFIX=$(getarg DISABLE_UNIQUE_SUFFIX=)
-export DISABLE_HOSTNAME_ID=$(getarg DISABLE_HOSTNAME_ID=)
-export DISABLE_ID_PREFIX=$(getarg DISABLE_ID_PREFIX=)
-export USE_FQDN_MINION_ID=$(getarg USE_FQDN_MINION_ID=)
-export USE_MAC_MINION_ID=$(getarg USE_MAC_MINION_ID=)
+getargbool 0 "${_prefix}.nosuffix" -d -y "DISABLE_UNIQUE_SUFFIX=" && DISABLE_UNIQUE_SUFFIX=1
+export DISABLE_UNIQUE_SUFFIX
+getargbool 0 "${_prefix}.nohostname" -d -y "DISABLE_HOSTNAME_ID=" && DISABLE_HOSTNAME_ID=1
+export DISABLE_HOSTNAME_ID
+getargbool 0 "${_prefix}.noprefix" -d -y "DISABLE_ID_PREFIX=" && DISABLE_ID_PREFIX=1
+export DISABLE_ID_PREFIX
+getargbool 0 "${_prefix}.usefqdn" -d -y "USE_FQDN_MINION_ID=" && USE_FQDN_MINION_ID=1
+export USE_FQDN_MINION_ID
+getargbool 0 "${_prefix}.usemac" -d -y "USE_MAC_MINION_ID=" && USE_MAC_MINION_ID=1
+export USE_MAC_MINION_ID
 
 # Debugging
-export kiwidebug=$(getarg kiwidebug=)
+getargbool 0 "${_prefix}.debug=" -d -y "kiwidebug=" && kiwidebug=1
+export kiwidebug

--- a/dracut-saltboot/saltboot/saltboot-timeout.sh
+++ b/dracut-saltboot/saltboot/saltboot-timeout.sh
@@ -6,12 +6,14 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 # if $root is specified, usually means terminal is already deployed and thus network is optional
 # wait for either network or device to boot from to be ready
 
-if [ -z "$root" ] || [ "$root"x == "saltbootx" ]; then
+if [ -z "$root" ] || [ "$root"x = "saltbootx" ]; then
   exit 0
 fi
 
 _name="$(str_replace "${root#block:}" '/' '\x2f')"
+# shellcheck disable=SC2034
 for f in wait-network.sh "devexists-$_name.sh"; do
+  # shellcheck disable=SC2154
   if [ ! -e "$hookdir/initqueue/finished/\$f" ] || ( . "$hookdir/initqueue/finished/\$f" ); then
     rm -f -- "$hookdir/initqueue/finished/wait-network.sh"
     rm -f -- "$hookdir/initqueue/finished/devexists-$_name.sh"


### PR DESCRIPTION
This PR introduces new rd.saltboot cmdline namespace:

String values:
MASTER => rd.saltboot.master
MINION_ID_PREFIX => rd.saltboot.id_prefix
SALT_TIMEOUT => rd.saltboot.timeout
SALT_STOP_TIMEOUT => rd.saltboot.stop_timout
salt_device => rd.saltboot.device

Boolean values, now only set if true:
DISABLE_UNIQUE_SUFFIX => rd.saltboot.nosuffix
DISABLE_HOSTNAME_ID => rd.saltboot.nohostname
DISABLE_ID_PREFIX => rd.saltboot.noprefix
USE_FQDN_MINION_ID => rd.saltboot.usefqdn
USE_MAC_MINION_ID => rd.saltboot.usemac
kiwidebug => rd.saltboot.debug

Important change is also booleans values are now set only if true on the command line. i.e. kiwidebug=0 on the command line now means kiwidebug variable is not set at all.

This PR also fixes shellcheck reported warnings and style issues.