### PR TITLE
Introduce wait check for minion start

### DIFF
--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -6,6 +6,8 @@ Tue Mar 24 10:43:46 UTC 2026 - Ondrej Holecek <oholecek@suse.com>
     using rd.saltboot.salt_start_timeout option (bsc#1260870)
   * Decouple salt key wait check to use separate configurable
     option rd.saltboot.salt_key_timeout, with default 60s
+  * Introduce rd.saltboot namespace for all options, mark old as
+    deprecated
 
 -------------------------------------------------------------------
 Mon Jan  5 12:47:13 UTC 2026 - Ondrej Holecek <oholecek@suse.com>

--- a/dracut-saltboot/dracut-saltboot.changes
+++ b/dracut-saltboot/dracut-saltboot.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Mar 24 10:43:46 UTC 2026 - Ondrej Holecek <oholecek@suse.com>
+
+- Update to version 1.2.0
+  * Add wait check for minion start (default 10s), configurable
+    using rd.saltboot.salt_start_timeout option (bsc#1260870)
+  * Decouple salt key wait check to use separate configurable
+    option rd.saltboot.salt_key_timeout, with default 60s
+
+-------------------------------------------------------------------
 Mon Jan  5 12:47:13 UTC 2026 - Ondrej Holecek <oholecek@suse.com>
 
 - Update to version 1.1.0

--- a/dracut-saltboot/dracut-saltboot.spec
+++ b/dracut-saltboot/dracut-saltboot.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package dracut-saltboot
 #
-# Copyright (c) 2025 SUSE LLC
+# Copyright (c) 2026 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           dracut-saltboot
-Version:        1.1.0
+Version:        1.2.0
 Release:        0
 Source:         dracut-saltboot-%{version}.tar.gz
 Summary:        Salt-based PXE network boot dracut module

--- a/dracut-saltboot/saltboot/saltboot-root.sh
+++ b/dracut-saltboot/saltboot/saltboot-root.sh
@@ -1,31 +1,51 @@
 #!/bin/sh
 
+command -v getarg > /dev/null || . /lib/dracut-lib.sh
+
 if [ -z "$root" ] ; then
   root=saltboot
 fi
 
+# shellcheck disable=SC2034
 rootok=1
 
 # If we don't have a server, we need dhcp
 if [ -z "$server" ] ; then
-    DHCPORSERVER="1"
+  # shellcheck disable=SC2034
+  DHCPORSERVER="1"
 fi;
 
+# Saltboot prefix
+prefix="rd.saltboot"
+
 # Salt minion modifiers
-export MASTER=$(getarg MASTER=)
-export MINION_ID_PREFIX=$(getarg MINION_ID_PREFIX=)
-export SALT_TIMEOUT=$(getarg SALT_TIMEOUT=)
-export SALT_STOP_TIMEOUT=$(getarg SALT_STOP_TIMEOUT=)
-export SALT_DEVICE=$(getarg salt_device=)
-export SALT_START_TIMEOUT=$(getarg rd.saltboot.salt_start_timeout=)
-export SALT_KEY_TIMEOUT=$(getarg rd.saltboot.salt_key_timeout=)
+MASTER="$(getarg "${prefix}.master=" -d -y "MASTER=")"
+export MASTER
+MINION_ID_PREFIX="$(getarg "${prefix}.id_prefix=" -d -y "MINION_ID_PREFIX=")"
+export MINION_ID_PREFIX
+SALT_DEVICE="$(getarg "${prefix}.salt_device=" -d -y "salt_device=")"
+export SALT_DEVICE
+SALT_TIMEOUT=$(getargnum 60 0 3600 "${prefix}.salt_timeout=" -d -y "SALT_TIMEOUT=")
+export SALT_TIMEOUT
+SALT_STOP_TIMEOUT=$(getargnum 15 0 3600 "${prefix}.salt_stop_timeout=" -d -y "SALT_STOP_TIMEOUT=")
+export SALT_STOP_TIMEOUT
+SALT_START_TIMEOUT=$(getargnum 10 0 3600 "${prefix}.salt_start_timeout=")
+export SALT_START_TIMEOUT
+SALT_KEY_TIMEOUT=$(getargnum 60 0 3600 "${prefix}.salt_key_timeout=")
+export SALT_KEY_TIMEOUT
 
 # Terminal naming modifiers
-export DISABLE_UNIQUE_SUFFIX=$(getarg DISABLE_UNIQUE_SUFFIX=)
-export DISABLE_HOSTNAME_ID=$(getarg DISABLE_HOSTNAME_ID=)
-export DISABLE_ID_PREFIX=$(getarg DISABLE_ID_PREFIX=)
-export USE_FQDN_MINION_ID=$(getarg USE_FQDN_MINION_ID=)
-export USE_MAC_MINION_ID=$(getarg USE_MAC_MINION_ID=)
+getargbool 0 "${prefix}.nosuffix" -d -y "DISABLE_UNIQUE_SUFFIX=" && DISABLE_UNIQUE_SUFFIX=1
+export DISABLE_UNIQUE_SUFFIX
+getargbool 0 "${prefix}.nohostname" -d -y "DISABLE_HOSTNAME_ID=" && DISABLE_HOSTNAME_ID=1
+export DISABLE_HOSTNAME_ID
+getargbool 0 "${prefix}.noprefix" -d -y "DISABLE_ID_PREFIX=" && DISABLE_ID_PREFIX=1
+export DISABLE_ID_PREFIX
+getargbool 0 "${prefix}.usefqdn" -d -y "USE_FQDN_MINION_ID=" && USE_FQDN_MINION_ID=1
+export USE_FQDN_MINION_ID
+getargbool 0 "${prefix}.usemac" -d -y "USE_MAC_MINION_ID=" && USE_MAC_MINION_ID=1
+export USE_MAC_MINION_ID
 
 # Debugging
-export KIWIDEBUG=$(getarg kiwidebug=)
+getargbool 0 "${prefix}.debug" -d -y "kiwidebug=" && KIWIDEBUG=1
+export KIWIDEBUG

--- a/dracut-saltboot/saltboot/saltboot-root.sh
+++ b/dracut-saltboot/saltboot/saltboot-root.sh
@@ -16,7 +16,9 @@ export MASTER=$(getarg MASTER=)
 export MINION_ID_PREFIX=$(getarg MINION_ID_PREFIX=)
 export SALT_TIMEOUT=$(getarg SALT_TIMEOUT=)
 export SALT_STOP_TIMEOUT=$(getarg SALT_STOP_TIMEOUT=)
-export salt_device=$(getarg salt_device=)
+export SALT_DEVICE=$(getarg salt_device=)
+export SALT_START_TIMEOUT=$(getarg rd.saltboot.salt_start_timeout=)
+export SALT_KEY_TIMEOUT=$(getarg rd.saltboot.salt_key_timeout=)
 
 # Terminal naming modifiers
 export DISABLE_UNIQUE_SUFFIX=$(getarg DISABLE_UNIQUE_SUFFIX=)
@@ -26,4 +28,4 @@ export USE_FQDN_MINION_ID=$(getarg USE_FQDN_MINION_ID=)
 export USE_MAC_MINION_ID=$(getarg USE_MAC_MINION_ID=)
 
 # Debugging
-export kiwidebug=$(getarg kiwidebug=)
+export KIWIDEBUG=$(getarg kiwidebug=)

--- a/dracut-saltboot/saltboot/saltboot.sh
+++ b/dracut-saltboot/saltboot/saltboot.sh
@@ -69,7 +69,7 @@ ls -l /dev/disk/by-id >&2
 echo "ls -l /dev/disk/by-path" >&2
 ls -l /dev/disk/by-path >&2
 
-salt_device=${salt_device:-${root#block:}}
+SALT_DEVICE=${SALT_DEVICE:-${root#block:}}
 
 if [ -f /usr/bin/venv-salt-call ] ; then
     INITRD_SALT_ETC=/etc/venv-salt-minion
@@ -86,7 +86,7 @@ else
 fi
 
 mkdir -p $NEWROOT
-if [ -n "$salt_device" ] && mount "$salt_device" $NEWROOT ; then
+if [ -n "$SALT_DEVICE" ] && mount "$SALT_DEVICE" $NEWROOT ; then
     for sd in $NEWROOT/etc/venv-salt-minion $NEWROOT/venv-salt-minion $NEWROOT/etc/salt $NEWROOT/salt $NEWROOT ; do
         if [ -f $sd/minion_id ] ; then # find valid salt configuration
             mkdir -p $INITRD_SALT_ETC
@@ -262,15 +262,20 @@ EOT
     rm -f $INITRD_SALT_ETC/minion.d/grains-startup-event.conf
 fi
 
-if [ -z "$kiwidebug" ];then
+if [ -z "$KIWIDEBUG" ];then
     $INITRD_SALT_MINION -d
 else
     $INITRD_SALT_MINION -d --log-file-level all
 fi
 
-sleep 1
+SALT_START_TIMEOUT=${SALT_START_TIMEOUT:-10}
+while [ ! -s "/var/run/$INITRD_SALT_MINION.pid" ] && [ "$SALT_START_TIMEOUT" -gt 0 ]; do
+    Echo "Waiting for minion to start ... (${SALT_START_TIMEOUT}s)"
+    sleep 1
+    SALT_START_TIMEOUT=$((SALT_START_TIMEOUT - 1))
+done
 
-SALT_PID=`cat /var/run/$INITRD_SALT_MINION.pid`
+SALT_PID=$(cat "/var/run/$INITRD_SALT_MINION.pid" 2>/dev/null)
 
 if [ -z "$SALT_PID" ] ; then
     Echo "Salt Minion did not start, rebooting in 10s"
@@ -278,22 +283,22 @@ if [ -z "$SALT_PID" ] ; then
     reboot -f
 fi
 
-SALT_TIMEOUT=${SALT_TIMEOUT:-60}
-
 MINION_ID="`$INITRD_SALT_CALL --local --out newline_values_only grains.get id`"
 MINION_FINGERPRINT="`$INITRD_SALT_CALL --local --out newline_values_only key.finger`"
-num=0
-while [ -z "$MINION_FINGERPRINT" ] ; do
-  num=$(( num + 1 ))
-  if [ "$num" == "$SALT_TIMEOUT" ] ; then
-    Echo "Can't get salt key, rebooting in 10s"
-    sleep 10
-    reboot -f
-  fi
-  Echo "Waiting for salt key..."
+
+SALT_KEY_TIMEOUT=${SALT_KEY_TIMEOUT:-60}
+while [ -z "$MINION_FINGERPRINT" ] && [ "$SALT_KEY_TIMEOUT" -gt 0 ]; do
+  Echo "Waiting for salt key... (${SALT_KEY_TIMEOUT}s)"
   sleep 1
   MINION_FINGERPRINT="`$INITRD_SALT_CALL --local --out newline_values_only key.finger`"
+  SALT_KEY_TIMEOUT=$((SALT_KEY_TIMEOUT - 1))
 done
+
+if [ -z "$MINION_FINGERPRINT" ] ; then
+    Echo "Cannot obtain salt key, rebooting in 10s"
+    sleep 10
+    reboot -f
+fi
 
 echo
 echo "SALT Minion ID:"
@@ -318,7 +323,7 @@ while kill -0 "$SALT_PID" >/dev/null 2>&1; do
      mount ${root#block:} $NEWROOT && [ -f $NEWROOT/etc/ImageVersion ]; then
     export systemIntegrity=fine
     export imageName=`cat $NEWROOT/etc/ImageVersion`
-    Echo "SUSE Manager server did not respond, trying local boot to\\\n$imageName"
+    Echo "Salt master did not respond, trying local boot to\\\n$imageName"
     sleep 5
     kill "$SALT_PID"
     sleep 1
@@ -339,7 +344,7 @@ if [ -f /salt_config ] ; then
 fi
 
 if [ "$systemIntegrity" = "unknown" ] ; then
-    Echo "SALT Minion did not create valid configuration, rebooting in 10s"
+    Echo "Salt minion did not create valid configuration, rebooting in 10s"
     sleep 10
     reboot -f
 fi


### PR DESCRIPTION
- introduce new wait check for minion start, configurable
using `rd.saltboot.salt_start_timeout` kernel option.

- redo wait check for minion key and adds specific option
`rd.saltboot.salt_key_timeout` option to modify it.

- consolidate variable naming to upper case
- drop old branding string

Issue: https://github.com/SUSE/spacewalk/issues/30175