### PR TITLE
Do not activate swap in the initrd

### DIFF
--- a/saltboot-formula/_states/saltboot.py
+++ b/saltboot-formula/_states/saltboot.py
@@ -966,10 +966,11 @@ def device_formatted(name, partitioning):
 
     fs_type = devmap[name]['format']
     if fs_type == 'swap':
-        ret = __states__['cmd.run']("mkswap -f {0}".format(opened_device))
-
-        __salt__['cmd.run_all']("swapon {0}".format(opened_device))
-        return ret
+        blkid_info = __salt__['disk.blkid'](opened_device).get(opened_device, {})
+        if blkid_info.get('TYPE') == 'swap':
+            ret['comment'] = "Device {0} is already swap, skipping mkswap.".format(opened_device)
+            return ret
+        return __states__['cmd.run']("mkswap -f {0}".format(opened_device))
     return __states__['blockdev.formatted'](opened_device, fs_type, force=True)
 
 # get image version and hash written to filesystem

--- a/saltboot-formula/saltboot-formula.changes
+++ b/saltboot-formula/saltboot-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 13 14:40:38 UTC 2026 - Ondrej Holecek <oholecek@suse.com>
+
+- Update to version 1.2.0
+  * Do not activate swap in the initrd (bsc#1260701)
+
+-------------------------------------------------------------------
 Fri Mar 27 14:56:52 UTC 2026 - Ondrej Holecek <oholecek@suse.com>
 
 - Update to version 1.1.0

--- a/saltboot-formula/saltboot-formula.spec
+++ b/saltboot-formula/saltboot-formula.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           saltboot-formula
-Version:        1.1.0
+Version:        1.2.0
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         saltboot-formula-%{version}.tar.gz


### PR DESCRIPTION
Activating it causes a conflict with systemd swap.mount and thus fail unit.

This commit also adds check if the device is already a swap so it is not recreated on each boot.

Issue https://github.com/SUSE/spacewalk/issues/30206